### PR TITLE
Test/erc20

### DIFF
--- a/modules/precompiles/test/erc20.config.ts
+++ b/modules/precompiles/test/erc20.config.ts
@@ -2,6 +2,7 @@ import { PrecompileConfig } from "../types/precompile.types";
 
 export type ERC20PrecompileConfig = PrecompileConfig<{
     amount: number;
+    feeFund: number;
 }>;
 
 const erc20PrecompileABI = [
@@ -24,4 +25,5 @@ export const erc20PrecompileConfig: ERC20PrecompileConfig = {
     abi: erc20PrecompileABI,
     contractAddress: "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
     amount: 1,
+    feeFund: 10000000,
 };

--- a/modules/precompiles/test/erc20.config.ts
+++ b/modules/precompiles/test/erc20.config.ts
@@ -1,8 +1,8 @@
-import { PrecompileConfig } from "../types/precompile.types"
+import { PrecompileConfig } from "../types/precompile.types";
 
 export type ERC20PrecompileConfig = PrecompileConfig<{
-    amount: number
-}>
+    amount: number;
+}>;
 
 const erc20PrecompileABI = [
     "function transfer(address to, uint256 amount) external",
@@ -15,13 +15,13 @@ const erc20PrecompileABI = [
     "function burn(address account, uint256 amount) external",
     "function burnFrom(address account, uint256 amount) external",
     "function transferOwnership(address newOwner) external",
-    "function owner() external view returns (address)"
-]
+    "function owner() external view returns (address)",
+    "event Transfer(address indexed from, address indexed to, uint256 value)",
+    "event Approval(address indexed owner, address indexed spender, uint256 value)",
+];
 
 export const erc20PrecompileConfig: ERC20PrecompileConfig = {
     abi: erc20PrecompileABI,
     contractAddress: "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
-    amount: 1
-}
-
-
+    amount: 1,
+};

--- a/modules/precompiles/test/erc20.test.ts
+++ b/modules/precompiles/test/erc20.test.ts
@@ -1,7 +1,11 @@
 import { expect } from "chai";
 import { erc20PrecompileConfig } from "./erc20.config";
 import { ethers } from "hardhat";
+import { findEvent, expectRevert } from "./testHelpers";
 
+// Notice: Using the double await pattern because we are testing on a live blockchain.
+// Transactions are asynchronous, and we must ensure they are fully confirmed on-chain before proceeding.
+// The first await sends the transaction, and the second await (tx.wait()) waits for it to be mined.
 describe("ERC20", () => {
     let abi;
     let contractAddress;
@@ -11,6 +15,8 @@ describe("ERC20", () => {
     let ownerSigner: any;
     let userSigner: any;
 
+    let burnMintAmount: bigint;
+
     beforeEach(async () => {
         abi = erc20PrecompileConfig.abi;
         contractAddress = erc20PrecompileConfig.contractAddress;
@@ -18,27 +24,95 @@ describe("ERC20", () => {
 
         ownerContract = new ethers.Contract(contractAddress, abi, ownerSigner);
         userContract = new ethers.Contract(contractAddress, abi, userSigner);
+
+        burnMintAmount = ethers.toBigInt(erc20PrecompileConfig.amount);
     });
 
-    /**
-     * 1. Mint test - ❌
-     * 2. Burn test - ❌
-     * 3. Burn0 test - ❌
-     * 4. BurnFrom test - ❌
-     * 5. Owner query test - ❌
-     * 6. Transfer ownership test - ❌
-     */
     describe("mint coins", () => {
         it("should mint tokens to the owner", async () => {
-            // Check that the owner has 0 tokens
             const beforeBalance = await ownerContract.balanceOf(userSigner.address);
 
-            // TODO: Change mint address
-            const tx = await ownerContract.mint(userSigner.address, erc20PrecompileConfig.amount);
-            await tx.wait();
+            const mintReceipt = await (await ownerContract.mint(userSigner.address, burnMintAmount)).wait();
+
+            const transferEvent = findEvent(mintReceipt, "Transfer");
+            expect(transferEvent).to.not.be.undefined;
 
             const afterBalance = await ownerContract.balanceOf(userSigner.address);
-            expect(afterBalance).to.equal(beforeBalance + BigInt(erc20PrecompileConfig.amount));
+            expect(afterBalance).to.equal(beforeBalance + burnMintAmount);
+        });
+
+        it("should prevent non-owner from minting tokens", async () => {
+            await expectRevert(userContract.mint(userSigner.address, burnMintAmount), "ERC20: minter is not the owner");
+        });
+    });
+
+    describe("burn coins", () => {
+        it("should burn specified amount", async () => {
+            const beforeBalance = await ownerContract.balanceOf(ownerSigner.address);
+
+            const mintReceipt = await (await ownerContract.mint(ownerSigner.address, burnMintAmount)).wait();
+
+            const mintGasFee = mintReceipt.gasUsed * mintReceipt.gasPrice;
+
+            const burnReceipt = await (await ownerContract.burn(burnMintAmount)).wait();
+            const burnGasFee = burnReceipt.gasUsed * burnReceipt.gasPrice;
+
+            const afterBurnBalance = await ownerContract.balanceOf(ownerSigner.address);
+
+            const expectedFinalBalance = beforeBalance - mintGasFee - burnGasFee;
+            expect(afterBurnBalance).to.equal(expectedFinalBalance);
+        });
+
+        it("should revert if trying to burn more than balance", async () => {
+            await expectRevert(ownerContract.burn(burnMintAmount), "ERC20: transfer amount exceeds balance");
+        });
+    });
+
+    describe("burn (owner-only burn)", () => {
+        it("should revert if sender is not owner", async () => {
+            await expectRevert(
+                userContract["burn(address,uint256)"](ownerSigner.address, burnMintAmount),
+                "ERC20: sender is not the owner",
+            );
+        });
+
+        it("should burn coins of spender if sender is owner", async () => {
+            await (await ownerContract.mint(userSigner.address, burnMintAmount)).wait();
+
+            const beforeBalance = await ownerContract.balanceOf(userSigner.address);
+
+            await (await ownerContract["burn(address,uint256)"](userSigner.address, burnMintAmount)).wait();
+
+            const afterBalance = await ownerContract.balanceOf(userSigner.address);
+
+            expect(afterBalance).to.equal(beforeBalance - burnMintAmount);
+        });
+    });
+
+    describe("burnFrom", () => {
+        it("should revert if spender does not have allowance", async () => {
+            await (await ownerContract.mint(userSigner.address, burnMintAmount)).wait();
+
+            await expectRevert(ownerContract.burnFrom(userSigner.address, burnMintAmount), "ERC20: insufficient allowance");
+        });
+
+        it("should burn coins if spender has allowance", async () => {
+            await (await ownerContract.mint(ownerSigner.address, burnMintAmount)).wait();
+
+            await (await ownerContract.approve(userSigner.address, burnMintAmount)).wait();
+
+            const initialAllowance = await userContract.allowance(ownerSigner.address, userSigner.address);
+            expect(initialAllowance).to.equal(burnMintAmount);
+
+            const beforeBalance = await userContract.balanceOf(ownerSigner.address);
+
+            await (await userContract.burnFrom(ownerSigner.address, burnMintAmount)).wait();
+
+            const afterBalance = await userContract.balanceOf(ownerSigner.address);
+            expect(afterBalance).to.equal(beforeBalance - burnMintAmount);
+
+            const finalAllowance = await userContract.allowance(ownerSigner.address, userSigner.address);
+            expect(finalAllowance).to.equal(0);
         });
     });
 });

--- a/modules/precompiles/test/erc20.test.ts
+++ b/modules/precompiles/test/erc20.test.ts
@@ -15,8 +15,10 @@ describe("ERC20", () => {
     let ownerSigner: any;
     let userSigner: any;
 
-    let burnMintAmount: bigint;
+    let testTokenAmount: bigint;
 
+    // Notice: user is acting as a faucet, providing the owner with enough tokens
+    // to cover transaction fees and execute mint, burn, and transferOwnership tests.
     beforeEach(async () => {
         abi = erc20PrecompileConfig.abi;
         contractAddress = erc20PrecompileConfig.contractAddress;
@@ -25,24 +27,45 @@ describe("ERC20", () => {
         ownerContract = new ethers.Contract(contractAddress, abi, ownerSigner);
         userContract = new ethers.Contract(contractAddress, abi, userSigner);
 
-        burnMintAmount = ethers.toBigInt(erc20PrecompileConfig.amount);
+        await (await userContract.transfer(ownerSigner.address, erc20PrecompileConfig.feeFund)).wait();
+
+        testTokenAmount = ethers.toBigInt(erc20PrecompileConfig.amount);
+    });
+
+    // Notice: This acts as a blockchain state reset by burning all tokens from the owner.
+    // Ensures that each test starts with a clean slate for the owner.
+    afterEach(async () => {
+        const currentOwner = await ownerContract.owner();
+        const ownerBalance = await ownerContract.balanceOf(ownerSigner.address);
+
+        const burnGasEstimate = await userContract.approve.estimateGas(ownerSigner.address, ownerBalance);
+
+        const exactApprovalAmount = ownerBalance - burnGasEstimate;
+
+        if (ownerBalance > 0) {
+            await (await ownerContract.approve(userSigner.address, exactApprovalAmount)).wait();
+            await (await userContract.burnFrom(ownerSigner.address, exactApprovalAmount)).wait();
+        }
+        if (currentOwner !== ownerSigner.address) {
+            await (await userContract.transferOwnership(ownerSigner.address)).wait();
+        }
     });
 
     describe("mint coins", () => {
         it("should mint tokens to the owner", async () => {
             const beforeBalance = await ownerContract.balanceOf(userSigner.address);
 
-            const mintReceipt = await (await ownerContract.mint(userSigner.address, burnMintAmount)).wait();
+            const mintReceipt = await (await ownerContract.mint(userSigner.address, testTokenAmount)).wait();
 
             const transferEvent = findEvent(mintReceipt, "Transfer");
             expect(transferEvent).to.not.be.undefined;
 
             const afterBalance = await ownerContract.balanceOf(userSigner.address);
-            expect(afterBalance).to.equal(beforeBalance + burnMintAmount);
+            expect(afterBalance).to.equal(beforeBalance + testTokenAmount);
         });
 
         it("should prevent non-owner from minting tokens", async () => {
-            await expectRevert(userContract.mint(userSigner.address, burnMintAmount), "ERC20: minter is not the owner");
+            await expectRevert(userContract.mint(userSigner.address, testTokenAmount), "ERC20: minter is not the owner");
         });
     });
 
@@ -50,11 +73,11 @@ describe("ERC20", () => {
         it("should burn specified amount", async () => {
             const beforeBalance = await ownerContract.balanceOf(ownerSigner.address);
 
-            const mintReceipt = await (await ownerContract.mint(ownerSigner.address, burnMintAmount)).wait();
+            const mintReceipt = await (await ownerContract.mint(ownerSigner.address, testTokenAmount)).wait();
 
             const mintGasFee = mintReceipt.gasUsed * mintReceipt.gasPrice;
 
-            const burnReceipt = await (await ownerContract.burn(burnMintAmount)).wait();
+            const burnReceipt = await (await ownerContract.burn(testTokenAmount)).wait();
             const burnGasFee = burnReceipt.gasUsed * burnReceipt.gasPrice;
 
             const afterBurnBalance = await ownerContract.balanceOf(ownerSigner.address);
@@ -64,55 +87,83 @@ describe("ERC20", () => {
         });
 
         it("should revert if trying to burn more than balance", async () => {
-            await expectRevert(ownerContract.burn(burnMintAmount), "ERC20: transfer amount exceeds balance");
+            const beforeBalance = await ownerContract.balanceOf(ownerSigner.address);
+            await expectRevert(ownerContract.burn(testTokenAmount + beforeBalance), "ERC20: transfer amount exceeds balance");
         });
     });
 
     describe("burn (owner-only burn)", () => {
         it("should revert if sender is not owner", async () => {
             await expectRevert(
-                userContract["burn(address,uint256)"](ownerSigner.address, burnMintAmount),
+                userContract["burn(address,uint256)"](ownerSigner.address, testTokenAmount),
                 "ERC20: sender is not the owner",
             );
         });
 
         it("should burn coins of spender if sender is owner", async () => {
-            await (await ownerContract.mint(userSigner.address, burnMintAmount)).wait();
+            await (await ownerContract.mint(userSigner.address, testTokenAmount)).wait();
 
             const beforeBalance = await ownerContract.balanceOf(userSigner.address);
 
-            await (await ownerContract["burn(address,uint256)"](userSigner.address, burnMintAmount)).wait();
+            await (await ownerContract["burn(address,uint256)"](userSigner.address, testTokenAmount)).wait();
 
             const afterBalance = await ownerContract.balanceOf(userSigner.address);
 
-            expect(afterBalance).to.equal(beforeBalance - burnMintAmount);
+            expect(afterBalance).to.equal(beforeBalance - testTokenAmount);
         });
     });
 
     describe("burnFrom", () => {
         it("should revert if spender does not have allowance", async () => {
-            await (await ownerContract.mint(userSigner.address, burnMintAmount)).wait();
+            await (await ownerContract.mint(userSigner.address, testTokenAmount)).wait();
 
-            await expectRevert(ownerContract.burnFrom(userSigner.address, burnMintAmount), "ERC20: insufficient allowance");
+            await expectRevert(ownerContract.burnFrom(userSigner.address, testTokenAmount), "ERC20: insufficient allowance");
         });
 
         it("should burn coins if spender has allowance", async () => {
-            await (await ownerContract.mint(ownerSigner.address, burnMintAmount)).wait();
-
-            await (await ownerContract.approve(userSigner.address, burnMintAmount)).wait();
+            await (await ownerContract.approve(userSigner.address, testTokenAmount)).wait();
 
             const initialAllowance = await userContract.allowance(ownerSigner.address, userSigner.address);
-            expect(initialAllowance).to.equal(burnMintAmount);
+            expect(initialAllowance).to.equal(testTokenAmount);
 
             const beforeBalance = await userContract.balanceOf(ownerSigner.address);
 
-            await (await userContract.burnFrom(ownerSigner.address, burnMintAmount)).wait();
+            await (await userContract.burnFrom(ownerSigner.address, testTokenAmount)).wait();
 
             const afterBalance = await userContract.balanceOf(ownerSigner.address);
-            expect(afterBalance).to.equal(beforeBalance - burnMintAmount);
+            expect(afterBalance).to.equal(beforeBalance - testTokenAmount);
 
             const finalAllowance = await userContract.allowance(ownerSigner.address, userSigner.address);
             expect(finalAllowance).to.equal(0);
+        });
+    });
+
+    describe("transferOwnership", () => {
+        describe("transferOwnership", () => {
+            it("should revert if sender is not the owner", async () => {
+                await expectRevert(userContract.transferOwnership(ownerSigner.address), "ERC20: sender is not the owner");
+            });
+
+            it("should transfer ownership if sender is owner", async () => {
+                await (await ownerContract.transferOwnership(userSigner.address)).wait();
+
+                const newOwner = await ownerContract.owner();
+                expect(newOwner).to.equal(userSigner.address);
+            });
+        });
+    });
+
+    describe("increaseAllowance", () => {
+        it("should correctly increase allowance", async () => {
+            const increaseAmount = ethers.toBigInt(erc20PrecompileConfig.amount);
+
+            const initialAllowance = await ownerContract.allowance(ownerSigner.address, userSigner.address);
+            expect(initialAllowance).to.equal(0);
+
+            await (await ownerContract.increaseAllowance(userSigner.address, increaseAmount)).wait();
+
+            const newAllowance = await ownerContract.allowance(ownerSigner.address, userSigner.address);
+            expect(newAllowance).to.equal(initialAllowance + increaseAmount);
         });
     });
 });

--- a/modules/precompiles/test/testHelpers.ts
+++ b/modules/precompiles/test/testHelpers.ts
@@ -1,0 +1,28 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+/**
+ * Finds an event in the transaction receipt logs.
+ * @param receipt The transaction receipt object.
+ * @param eventName The name of the event to find.
+ * @returns The event log if found, otherwise undefined.
+ */
+export const findEvent = (receipt: any, eventName: string) => {
+    const eventHash = ethers.id(`${eventName}(address,address,uint256)`);
+    return receipt.logs.find((log: { topics: string[] }) => log.topics[0] === eventHash);
+};
+
+/**
+ * Asserts that a transaction reverts with a specific error message.
+ * @param tx The transaction promise that should revert.
+ * @param expectedError The expected revert error message.
+ */
+export const expectRevert = async (tx: Promise<any>, expectedError: string) => {
+    try {
+        await tx;
+        expect.fail(`Expected transaction to revert with '${expectedError}', but it did not`);
+    } catch (error: any) {
+        // console.log("Full error message:", error);
+        expect(error.message).to.contain(expectedError);
+    }
+};

--- a/packages/shared/config/src/hardhat/constants.ts
+++ b/packages/shared/config/src/hardhat/constants.ts
@@ -5,7 +5,6 @@ export const DEFAULT_HARDHAT_CONFIG: HardhatUserConfig = {
     networks: {
         xrplevm_localnet: {
             url: "http://localhost:8545",
-            // gasPrice: 0,
         },
         xrplevm_devnet: {
             url: "https://rpc.xrplevm.org",

--- a/packages/shared/config/src/hardhat/constants.ts
+++ b/packages/shared/config/src/hardhat/constants.ts
@@ -5,7 +5,7 @@ export const DEFAULT_HARDHAT_CONFIG: HardhatUserConfig = {
     networks: {
         xrplevm_localnet: {
             url: "http://localhost:8545",
-            gasPrice: 0,
+            // gasPrice: 0,
         },
         xrplevm_devnet: {
             url: "https://rpc.xrplevm.org",


### PR DESCRIPTION
# [TA-3924]: [e2e-testsuite] Implement erc20 precompiles tests

## Changes :hammer_and_wrench:


### modules/precompiles

- Extended ERC20 ABI.  
- Added tests for ERC20 functions (mint, burn, allowance, etc.).  
- Added some testHelper functions. Done in the same module and not in `packages/shared` to avoid installing Hardhat there.  
- Removed `gasPrice = 0` from the Hardhat config, as it caused conflicts during tests (the chain's gas price dynamically increases, and setting it to `0` resulted in errors).  
- 
### Considerations

- The `beforeEach` and `afterEach` hooks significantly increase test execution time since the tests run on a live blockchain, requiring transactions to be finalized before proceeding.  
- For the same reason, a **double-await pattern** is used throughout the tests to ensure transactions are fully confirmed before executing the next step or assertion.  
