### PR TITLE
[TA-4275]: Test query ERC20

### DIFF
--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -1,13 +1,13 @@
 {
     "hardhat": {
-        "defaultNetwork": "xrplevm_devnet",
+        "defaultNetwork": "xrplevm_localnet",
         "solidity": "0.8.20",
         "networks": {
-            "xrplevm_devnet": {
-                "url": "https://rpc.xrplevm.org",
+            "xrplevm_localnet": {
+                "url": "http://localhost:8545",
                 "accounts": [
-                    "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9",
-                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100"
+                    "1bacb3ef3d80d8f148299bd21a56d9a78048dc2e20ddab25713a408f2d1f4d5e",
+                    "d8161fd5fdf4eb216a6556dc639a2543b0ed9abdbceb9971fe08cfba56f588c8"
                 ]
             }
         }
@@ -34,6 +34,7 @@
                 "event Approval(address indexed owner, address indexed spender, uint256 value)"
             ],
             "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
+            "owner": "0x9159C650e1D7E10a17c450eb3D50778aBA593D61",
             "amount": "1",
             "feeFund": "10000000"
         }

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -15,6 +15,7 @@
     "erc20": {
         "abi": [
             "function transfer(address to, uint256 amount) external",
+            "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
             "function mint(address to, uint256 amount) external",
             "function approve(address spender, uint256 amount) external returns (bool)",
             "function balanceOf(address account) external view returns (uint256)",
@@ -25,6 +26,7 @@
             "function burnFrom(address account, uint256 amount) external",
             "function transferOwnership(address newOwner) external",
             "function owner() external view returns (address)",
+            "function totalSupply() external view returns (uint256)",
             "event Transfer(address indexed from, address indexed to, uint256 value)",
             "event Approval(address indexed owner, address indexed spender, uint256 value)"
         ],

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -12,10 +12,26 @@
             }
         }
     },
+    "chain": {
+        "id": "xrplevm_localnet",
+        "name": "xrplevm_localnet",
+        "chainId": 100,
+        "env": "localnet",
+        "type": "evm",
+        "symbol": "XRP",
+        "nativeToken": {
+            "id": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
+            "symbol": "XRP",
+            "decimals": 18,
+            "name": "XRP",
+            "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
+        }
+    },
     "contracts": {
         "erc20": {
             "abi": [
                 "function transfer(address to, uint256 amount) external",
+                "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
                 "function mint(address to, uint256 amount) external",
                 "function approve(address spender, uint256 amount) external returns (bool)",
                 "function balanceOf(address account) external view returns (uint256)",

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -1,37 +1,41 @@
 {
     "hardhat": {
-        "defaultNetwork": "xrplevm_localnet",
+        "defaultNetwork": "xrplevm_devnet",
         "solidity": "0.8.20",
         "networks": {
-            "xrplevm_localnet": {
-                "url": "http://localhost:8545",
+            "xrplevm_devnet": {
+                "url": "https://rpc.xrplevm.org",
                 "accounts": [
-                    "1bacb3ef3d80d8f148299bd21a56d9a78048dc2e20ddab25713a408f2d1f4d5e",
-                    "d8161fd5fdf4eb216a6556dc639a2543b0ed9abdbceb9971fe08cfba56f588c8"
+                    "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9",
+                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100"
                 ]
             }
         }
     },
-    "erc20": {
-        "abi": [
-            "function transfer(address to, uint256 amount) external",
-            "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
-            "function mint(address to, uint256 amount) external",
-            "function approve(address spender, uint256 amount) external returns (bool)",
-            "function balanceOf(address account) external view returns (uint256)",
-            "function increaseAllowance(address spender, uint256 addedValue) external returns (bool)",
-            "function allowance(address owner, address spender) external view returns (uint256)",
-            "function burn(uint256 amount) external",
-            "function burn(address account, uint256 amount) external",
-            "function burnFrom(address account, uint256 amount) external",
-            "function transferOwnership(address newOwner) external",
-            "function owner() external view returns (address)",
-            "function totalSupply() external view returns (uint256)",
-            "event Transfer(address indexed from, address indexed to, uint256 value)",
-            "event Approval(address indexed owner, address indexed spender, uint256 value)"
-        ],
-        "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
-        "amount": "1",
-        "feeFund": "10000000"
+    "contracts": {
+        "erc20": {
+            "abi": [
+                "function transfer(address to, uint256 amount) external",
+                "function mint(address to, uint256 amount) external",
+                "function approve(address spender, uint256 amount) external returns (bool)",
+                "function balanceOf(address account) external view returns (uint256)",
+                "function increaseAllowance(address spender, uint256 addedValue) external returns (bool)",
+                "function allowance(address owner, address spender) external view returns (uint256)",
+                "function burn(uint256 amount) external",
+                "function burn(address account, uint256 amount) external",
+                "function burnFrom(address account, uint256 amount) external",
+                "function transferOwnership(address newOwner) external",
+                "function owner() external view returns (address)",
+                "function totalSupply() external view returns (uint256)",
+                "function name() external view returns (string)",
+                "function symbol() external view returns (string)",
+                "function decimals() external view returns (uint8)",
+                "event Transfer(address indexed from, address indexed to, uint256 value)",
+                "event Approval(address indexed owner, address indexed spender, uint256 value)"
+            ],
+            "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
+            "amount": "1",
+            "feeFund": "10000000"
+        }
     }
 }

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -1,30 +1,15 @@
 {
     "hardhat": {
-        "defaultNetwork": "xrplevm_localnet",
+        "defaultNetwork": "xrplevm_testnet",
         "solidity": "0.8.20",
         "networks": {
-            "xrplevm_localnet": {
-                "url": "http://localhost:8545",
+            "xrplevm_testnet": {
+                "url": "https://rpc.testnet.xrplevm.org",
                 "accounts": [
-                    "1bacb3ef3d80d8f148299bd21a56d9a78048dc2e20ddab25713a408f2d1f4d5e",
-                    "d8161fd5fdf4eb216a6556dc639a2543b0ed9abdbceb9971fe08cfba56f588c8"
+                    "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9",
+                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100"
                 ]
             }
-        }
-    },
-    "chain": {
-        "id": "xrplevm_localnet",
-        "name": "xrplevm_localnet",
-        "chainId": 100,
-        "env": "localnet",
-        "type": "evm",
-        "symbol": "XRP",
-        "nativeToken": {
-            "id": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
-            "symbol": "XRP",
-            "decimals": 18,
-            "name": "XRP",
-            "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
         }
     },
     "contracts": {
@@ -49,10 +34,24 @@
                 "event Transfer(address indexed from, address indexed to, uint256 value)",
                 "event Approval(address indexed owner, address indexed spender, uint256 value)"
             ],
-            "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
-            "owner": "0x9159C650e1D7E10a17c450eb3D50778aBA593D61",
+            "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+            "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
             "amount": "1",
             "feeFund": "10000000"
+        }
+    },
+    "chain": {
+        "id": "xrpl-evm",
+        "name": "xrpl-evm",
+        "chainId": 1449000,
+        "env": "testnet",
+        "type": "evm",
+        "symbol": "XRP",
+        "nativeToken": {
+            "symbol": "XRP",
+            "decimals": 18,
+            "name": "XRP",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         }
     }
 }

--- a/modules/evm/src/precompiles/erc20/errors/errors.ts
+++ b/modules/evm/src/precompiles/erc20/errors/errors.ts
@@ -1,8 +1,8 @@
 export enum ERC20Errors {
     MINTER_IS_NOT_OWNER = "minter is not the owner",
-    INVALID_COINS = "0token: invalid coins",
+    INVALID_COINS = "invalid coins",
     TRANSFER_AMOUNT_EXCEEDS_BALANCE = "transfer amount exceeds balance",
     SENDER_IS_NOT_OWNER = "sender is not the owner",
     INSUFFICIENT_ALLOWANCE = "insufficient allowance",
-    ZERO_TOKEN_AMOUNT_NOT_POSITIVE = "coin 0token amount is not positive",
+    ZERO_TOKEN_AMOUNT_NOT_POSITIVE = "amount is not positive",
 }

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -31,7 +31,7 @@ describe("ERC20", () => {
 
     let tokenAmount: bigint;
 
-    const { erc20 } = moduleConfig;
+    const { erc20 } = moduleConfig.contracts;
 
     // Notice: user is acting as a faucet, providing the owner with enough tokens
     // to cover transaction fees and execute mint, burn, and transferOwnership tests.
@@ -52,7 +52,7 @@ describe("ERC20", () => {
     // Notice: This acts as a blockchain state reset by burning all tokens from the owner.
     // Ensures that each test starts with a clean slate for the owner.
     afterEach(async () => {
-        await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner);
+        // await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner);
     });
 
     describe("get functions", () => {
@@ -75,6 +75,15 @@ describe("ERC20", () => {
         it("should get owner's balance", async () => {
             const ownerBalance = await userContract.balanceOf(ownerSigner.address);
             expect(ownerBalance).to.equal(erc20.feeFund);
+        });
+        it("should return the correct name, symbol, and decimals", async () => {
+            const tokenName = await ownerContract.name();
+            const tokenSymbol = await ownerContract.symbol();
+            const tokenDecimals = await ownerContract.decimals();
+
+            expect(tokenName).to.equal("XRP");
+            expect(tokenSymbol).to.equal("XRP");
+            expect(tokenDecimals).to.equal(18);
         });
     });
 

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -61,31 +61,48 @@ describe("ERC20", () => {
         });
     }
 
-    describe("get functions", () => {
+    describe("owner", () => {
         it("should return the correct owner", async () => {
             const currentOwner = await ownerContract.owner();
             expect(currentOwner).to.equal(owner);
         });
+    });
 
+    describe("totalSupply", () => {
         it("should have a total supply greater than 10000000000000000000000000n", async () => {
             const totalSupply = await ownerContract.totalSupply();
             expect(totalSupply).to.be.gt(100000000000000000000n);
         });
+    });
 
-        it("should check that allowance is 0 ", async () => {
+    describe("allowance", () => {
+        it("should check that allowance is 0", async () => {
             await executeTx(ownerContract.approve(userSigner.address, 0n));
             const allowance = await ownerContract.allowance(ownerSigner.address, userSigner.address);
             expect(allowance).to.equal(0n);
         });
+    });
 
-        it("should return the correct name, symbol, and decimals", async () => {
+    describe("name", () => {
+        it("should return the correct name", async () => {
             assertChainEnvironments(["devnet", "testnet", "mainnet"], chain as unknown as Chain);
             const tokenName = await ownerContract.name();
-            const tokenSymbol = await ownerContract.symbol();
-            const tokenDecimals = await ownerContract.decimals();
-
             expect(tokenName).to.equal("XRP");
+        });
+    });
+
+    describe("symbol", () => {
+        it("should return the correct symbol", async () => {
+            assertChainEnvironments(["devnet", "testnet", "mainnet"], chain as unknown as Chain);
+            const tokenSymbol = await ownerContract.symbol();
             expect(tokenSymbol).to.equal("XRP");
+        });
+    });
+
+    describe("decimals", () => {
+        it("should return the correct decimals", async () => {
+            assertChainEnvironments(["devnet", "testnet", "mainnet"], chain as unknown as Chain);
+            const tokenDecimals = await ownerContract.decimals();
             expect(tokenDecimals).to.equal(18);
         });
     });

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -32,6 +32,8 @@ describe("ERC20", () => {
     let tokenAmount: bigint;
 
     const { erc20 } = moduleConfig.contracts;
+    const { defaultNetwork } = moduleConfig.hardhat;
+    const { owner } = moduleConfig.contracts.erc20;
 
     // Notice: user is acting as a faucet, providing the owner with enough tokens
     // to cover transaction fees and execute mint, burn, and transferOwnership tests.
@@ -52,13 +54,13 @@ describe("ERC20", () => {
     // Notice: This acts as a blockchain state reset by burning all tokens from the owner.
     // Ensures that each test starts with a clean slate for the owner.
     afterEach(async () => {
-        // await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner);
+        await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner);
     });
 
     describe("get functions", () => {
         it("should return the correct owner", async () => {
             const currentOwner = await ownerContract.owner();
-            expect(currentOwner).to.equal(ownerSigner.address);
+            expect(currentOwner).to.equal(owner);
         });
 
         it("should return the correct total supply", async () => {
@@ -76,18 +78,19 @@ describe("ERC20", () => {
             const ownerBalance = await userContract.balanceOf(ownerSigner.address);
             expect(ownerBalance).to.equal(erc20.feeFund);
         });
-        it("should return the correct name, symbol, and decimals", async () => {
+
+        (defaultNetwork === "xrplevm_localnet" ? it.skip : it)("should return the correct name, symbol, and decimals", async () => {
             const tokenName = await ownerContract.name();
             const tokenSymbol = await ownerContract.symbol();
             const tokenDecimals = await ownerContract.decimals();
 
-            expect(tokenName).to.equal("XRP");
-            expect(tokenSymbol).to.equal("XRP");
+            expect(tokenName).to.equal("");
+            expect(tokenSymbol).to.equal("");
             expect(tokenDecimals).to.equal(18);
         });
     });
 
-    describe("mint coins", () => {
+    (defaultNetwork !== "xrplevm_localnet" ? describe.skip : describe)("mint coins", () => {
         it("should mint tokens to the user", async () => {
             const beforeBalance = await ownerContract.balanceOf(userSigner.address);
 
@@ -108,7 +111,7 @@ describe("ERC20", () => {
         });
     });
 
-    describe("burn coins", () => {
+    (defaultNetwork !== "xrplevm_localnet" ? describe.skip : describe)("burn coins", () => {
         it("should burn specified amount", async () => {
             const beforeBalance = await ownerContract.balanceOf(ownerSigner.address);
 
@@ -130,7 +133,7 @@ describe("ERC20", () => {
         });
     });
 
-    describe("burn (owner-only burn)", () => {
+    (defaultNetwork !== "xrplevm_localnet" ? describe.skip : describe)("burn (owner-only burn)", () => {
         it("should revert if sender is not owner", async () => {
             await expectRevert(userContract["burn(address,uint256)"](ownerSigner.address, tokenAmount), ERC20Errors.SENDER_IS_NOT_OWNER);
         });
@@ -146,7 +149,7 @@ describe("ERC20", () => {
         });
     });
 
-    describe("burnFrom", () => {
+    (defaultNetwork !== "xrplevm_localnet" ? describe.skip : describe)("burnFrom", () => {
         it("should revert if spender does not have allowance", async () => {
             await executeTx(ownerContract.mint(userSigner.address, tokenAmount));
 
@@ -171,7 +174,7 @@ describe("ERC20", () => {
         });
     });
 
-    describe("transferOwnership", () => {
+    (defaultNetwork !== "xrplevm_localnet" ? describe.skip : describe)("transferOwnership", () => {
         it("should revert if sender is not the owner", async () => {
             await expectRevert(userContract.transferOwnership(ownerSigner.address), ERC20Errors.SENDER_IS_NOT_OWNER);
         });

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -116,17 +116,15 @@ describe("ERC20", () => {
 
     describe("burn coins", () => {
         before(function () {
-            assertChainEnvironments(["localnet"], chain as unknown as Chain);
+            assertChainEnvironments(["localnet", "devnet", "testnet"], chain as unknown as Chain);
         });
         it("should burn specified amount", async () => {
             const beforeBalance = await ownerContract.balanceOf(ownerSigner.address);
 
-            const { gasCost: mintGasFee } = await executeTx(ownerContract.mint(ownerSigner.address, tokenAmount));
-
             const { gasCost: burnGasFee } = await executeTx(ownerContract.burn(tokenAmount));
 
             const afterBalance = await ownerContract.balanceOf(ownerSigner.address);
-            const expectedFinalBalance = beforeBalance - mintGasFee - burnGasFee;
+            const expectedFinalBalance = beforeBalance - tokenAmount - burnGasFee;
             expect(afterBalance).to.equal(expectedFinalBalance);
         });
 
@@ -148,7 +146,6 @@ describe("ERC20", () => {
         });
 
         it("should burn coins of spender if sender is owner", async () => {
-            await executeTx(ownerContract.mint(userSigner.address, tokenAmount));
             const beforeBalance = await ownerContract.balanceOf(userSigner.address);
 
             await executeTx(ownerContract["burn(address,uint256)"](userSigner.address, tokenAmount));
@@ -160,11 +157,9 @@ describe("ERC20", () => {
 
     describe("burnFrom", () => {
         before(function () {
-            assertChainEnvironments(["localnet"], chain as unknown as Chain);
+            assertChainEnvironments(["localnet", "devnet", "testnet"], chain as unknown as Chain);
         });
         it("should revert if spender does not have allowance", async () => {
-            await executeTx(ownerContract.mint(userSigner.address, tokenAmount));
-
             await expectRevert(ownerContract.burnFrom(userSigner.address, tokenAmount), ERC20Errors.INSUFFICIENT_ALLOWANCE);
         });
 

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -65,9 +65,9 @@ describe("ERC20", () => {
             expect(currentOwner).to.equal(ownerSigner.address);
         });
 
-        it("should return the correct total supply", async () => {
+        it("should have a total supply greater than 10000000000000000000000000n", async () => {
             const totalSupply = await ownerContract.totalSupply();
-            expect(totalSupply).to.equal(1000000000000000000000000002n);
+            expect(totalSupply).to.be.gt(10000000000000000000000000n);
         });
 
         it("should check that allowance is 0 ", async () => {


### PR DESCRIPTION
# [TA-4275]: Test query ERC20

## Changes :hammer_and_wrench:

### modules/evm

- Add tests for getter functions: owner, totalSupply, name, symbol, and decimals. 
- Left balanceOf specific test because is largely used within the tests, so its already largely tested. TotalSupply functionality will be tested on axelar module.
- Improved error values (to handle every kind of tokens).
- Add functionality to handle differently localnet than testnet, devnet and mainnet.
- Add transferFrom test.