### PR TITLE
[TA-4279]: Add Cleanup to Axelar tests

### DIFF
--- a/modules/axelar/module.config.example.json
+++ b/modules/axelar/module.config.example.json
@@ -3,58 +3,44 @@
         "url": "https://api.axelar.network",
         "apiUrl": "https://api.axelar.network",
         "gmpUrl": "https://gmp.axelar.network",
-        "sourceChain": {
-            "id": "xrpl-evm-devnet",
-            "name": "xrpl-evm-devnet",
+        "destinationChain": {
+            "name": "XRPL",
             "chainId": 100,
-            "env": "devnet",
+            "id": "xrpl",
+            "env": "testnet",
+            "type": "xrp",
+            "tokenId": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
+            "axelarAmplifierGatewayAddress": "rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2",
+            "interchainTokenServiceAddress": "rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2",
+            "urls": {
+                "ws": "wss://s.altnet.rippletest.net:51233"
+            },
+            "account": {
+                "privateKey": "sEdVwXN5PtffKz9RZHv5EQVjxbpttza"
+            }
+        },
+        "sourceChain": {
+            "id": "xrpl-evm",
+            "name": "xrpl-evm",
+            "chainId": 1449000,
+            "env": "testnet",
             "type": "evm",
             "symbol": "XRP",
             "nativeToken": {
-                "id": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
+                "id": "0x85f75bb7fd0753565c1d2cb59bd881970b52c6f06f3472769ba7b48621cd9d23",
                 "symbol": "XRP",
                 "decimals": 18,
                 "name": "XRP",
-                "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
+                "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
             },
-            "door": "0x1a7580C2ef5D485E069B7cf1DF9f6478603024d3",
-            "tokenId": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
-            "axelarGatewayAddress": "0xF128c84c3326727c3e155168daAa4C0156B87AD1",
-            "interchainTokenFactory": "0xECd104DDf368d016ecf5C4c7de60Bdc90565D81a",
-            "interchainTokenServiceAddress": "0x1a7580C2ef5D485E069B7cf1DF9f6478603024d3",
+            "axelarGatewayAddress": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+            "interchainTokenFactory": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
+            "interchainTokenServiceAddress": "0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C",
             "interchainTokenDeployedAddress": "0xb66d931bC569D60dA5d9852Ea0c1ed0484B72677",
-            "saltTokenFactory": "ITS Factory xrpl-evm-devnet devnet-amplifier v0",
-            "axelarGasServiceAddress": "0x8b4Cc5Fb89B68aE93aDfa67990419144e7395Dd1",
-            "callContractAddress": "0xec4bd13fcc8b9580ebd44f6e6a4bd12ee468414a",
+            "axelarGasServiceAddress": "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+            "callContractAddress": "0xbd753c4bec615d7840698a0d2bdd3d62241afdfa",
             "urls": {
                 "rpc": "https://rpc.xrplevm.org"
-            },
-            "account": {
-                "privateKey": "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9"
-            }
-        },
-        "destinationChain": {
-            "name": "avalanche-fuji",
-            "chainId": 43113,
-            "env": "devnet",
-            "type": "evm",
-            "nativeToken": {
-                "symbol": "XRP",
-                "decimals": 18,
-                "name": "XRP",
-                "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
-            },
-            "tokenId": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
-            "axelarGatewayAddress": "0xF128c84c3326727c3e155168daAa4C0156B87AD1",
-            "interchainTokenFactory": "0xdB7d6A5B8d37a4f34BC1e7ce0d0B8a9DDA124871",
-            "saltTokenFactory": "ITS Factory v1.0.0 consensus devnet-amplifier2",
-            "interchainTokenServiceAddress": "0x2269B93c8D8D4AfcE9786d2940F5Fcd4386Db7ff",
-            "interchainTokenDeployedAddress": "0x3F529fB73B168c260fc6ccEF73B909cfb8FCC155",
-            "axelarGasServiceAddress": "0x1179d44e69ba5252B7478a8602617d5EEeb2F377",
-            "callContractAddress": "0x1cd15e16400214bee948417f58ba1b3badb7dd7e",
-            "urls": {
-                "rpc": "https://api.avax-test.network/ext/bc/C/rpc",
-                "ws": "https://api.avax-test.network/ext/bc/C/rpc"
             },
             "account": {
                 "privateKey": "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9"

--- a/modules/axelar/module.config.example.json
+++ b/modules/axelar/module.config.example.json
@@ -40,7 +40,7 @@
             "axelarGasServiceAddress": "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
             "callContractAddress": "0xbd753c4bec615d7840698a0d2bdd3d62241afdfa",
             "urls": {
-                "rpc": "https://rpc.xrplevm.org"
+                "rpc": "https://rpc.testnet.xrplevm.org"
             },
             "account": {
                 "privateKey": "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9"

--- a/modules/axelar/module.config.example.json
+++ b/modules/axelar/module.config.example.json
@@ -3,47 +3,55 @@
         "url": "https://api.axelar.network",
         "apiUrl": "https://api.axelar.network",
         "gmpUrl": "https://gmp.axelar.network",
-        "destinationChain": {
-            "name": "XRPL",
-            "chainId": 100,
-            "id": "xrpl",
-            "env": "testnet",
-            "type": "xrp",
-            "tokenId": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
-            "axelarAmplifierGatewayAddress": "rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2",
-            "interchainTokenServiceAddress": "rNrjh1KGZk2jBR3wPfAQnoidtFFYQKbQn2",
-            "urls": {
-                "ws": "wss://s.altnet.rippletest.net:51233"
-            },
-            "account": {
-                "privateKey": "sEdVwXN5PtffKz9RZHv5EQVjxbpttza"
-            }
-        },
         "sourceChain": {
-            "id": "xrpl-evm",
-            "name": "xrpl-evm",
-            "chainId": 1449000,
-            "env": "testnet",
+            "id": "xrpl-evm-devnet",
+            "name": "xrpl-evm-devnet",
+            "chainId": 1440002,
+            "env": "devnet",
             "type": "evm",
             "symbol": "XRP",
             "nativeToken": {
-                "id": "0x85f75bb7fd0753565c1d2cb59bd881970b52c6f06f3472769ba7b48621cd9d23",
+                "id": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
                 "symbol": "XRP",
                 "decimals": 18,
                 "name": "XRP",
-                "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+                "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
             },
-            "axelarGatewayAddress": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-            "interchainTokenFactory": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
-            "interchainTokenServiceAddress": "0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C",
+            "door": "0x1a7580C2ef5D485E069B7cf1DF9f6478603024d3",
+            "axelarGatewayAddress": "0xF128c84c3326727c3e155168daAa4C0156B87AD1",
+            "interchainTokenFactory": "0xECd104DDf368d016ecf5C4c7de60Bdc90565D81a",
+            "interchainTokenServiceAddress": "0x1a7580C2ef5D485E069B7cf1DF9f6478603024d3",
             "interchainTokenDeployedAddress": "0xb66d931bC569D60dA5d9852Ea0c1ed0484B72677",
-            "axelarGasServiceAddress": "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
-            "callContractAddress": "0xbd753c4bec615d7840698a0d2bdd3d62241afdfa",
+            "axelarGasServiceAddress": "0x8b4Cc5Fb89B68aE93aDfa67990419144e7395Dd1",
+            "callContractAddress": "0xec4bd13fcc8b9580ebd44f6e6a4bd12ee468414a",
+            "callContractWithTokenAddress": "0xec4bd13fcc8b9580ebd44f6e6a4bd12ee468414a",
             "urls": {
-                "rpc": "https://rpc.testnet.xrplevm.org"
+                "rpc": "https://rpc.xrplevm.org"
             },
             "account": {
                 "privateKey": "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9"
+            }
+        },
+        "destinationChain": {
+            "id": "xrpl-dev",
+            "name": "xrpl-dev",
+            "chainId": 100,
+            "env": "devnet",
+            "type": "xrp",
+            "axelarAmplifierGatewayAddress": "rGAbJZEzU6WaYv5y1LfyN7LBBcQJ3TxsKC",
+            "interchainTokenServiceAddress": "rGAbJZEzU6WaYv5y1LfyN7LBBcQJ3TxsKC",
+            "nativeToken": {
+                "id": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
+                "symbol": "XRP",
+                "decimals": 18,
+                "name": "XRP"
+            },
+            "tokenId": "0xbfb47d376947093b7858c1c59a4154dd291d5b2251cb56a6f7159a070f0bd518",
+            "urls": {
+                "ws": "wss://s.devnet.rippletest.net:51233"
+            },
+            "account": {
+                "privateKey": "sEdVwXN5PtffKz9RZHv5EQVjxbpttza"
             }
         },
         "interchainTransferOptions": {
@@ -52,12 +60,12 @@
             "gasLimit": 300000,
             "maxRetries": 50,
             "retryDelay": 10000,
-            "timeout": 500000
+            "timeout": 100000
         },
         "gmpOptions": {
             "maxRetries": 50,
             "retryDelay": 10000,
-            "timeout": 1000000
+            "timeout": 100000
         }
     },
     "hardhat": {

--- a/modules/axelar/test/cross-chain-transfers/evm-evm/interchain-token.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/evm-evm/interchain-token.test.ts
@@ -10,7 +10,7 @@ import BigNumber from "bignumber.js";
 import { assertInterchainBalanceUpdate } from "./interchain-token.helpers";
 import { HardhatErrors } from "@testing/hardhat/errors";
 
-describe.skip("Interchain Token Deployment EVM - EVM", () => {
+describe("Interchain Token Deployment EVM - EVM", () => {
     const { sourceChain, destinationChain, interchainTransferOptions } = config.axelar;
     const pollingOpts = interchainTransferOptions as PollingOptions;
 

--- a/modules/axelar/test/cross-chain-transfers/evm-evm/interchain-token.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/evm-evm/interchain-token.test.ts
@@ -10,7 +10,7 @@ import BigNumber from "bignumber.js";
 import { assertInterchainBalanceUpdate } from "./interchain-token.helpers";
 import { HardhatErrors } from "@testing/hardhat/errors";
 
-describe("Interchain Token Deployment EVM - EVM", () => {
+describe.skip("Interchain Token Deployment EVM - EVM", () => {
     const { sourceChain, destinationChain, interchainTransferOptions } = config.axelar;
     const pollingOpts = interchainTransferOptions as PollingOptions;
 

--- a/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
@@ -15,6 +15,7 @@ import { EvmTranslator } from "@firewatch/bridge/translators/evm";
 import { XrpTranslator } from "@firewatch/bridge/translators/xrp";
 import { HardhatErrors } from "@testing/hardhat/errors";
 import { expectRevert } from "@testing/hardhat/utils";
+import { ERC20 } from "@shared/evm/contracts";
 
 describe("Cross-Chain Native Transfer", () => {
     const { sourceChain, destinationChain, interchainTransferOptions } = config.axelar;
@@ -33,6 +34,7 @@ describe("Cross-Chain Native Transfer", () => {
 
     let evmChainTranslator: EvmTranslator;
     let xrplChainTranslator: XrpTranslator;
+    let tokenContract: ERC20;
 
     before(async () => {
         assertChainTypes(["evm"], sourceChain as unknown as AxelarBridgeChain);
@@ -52,6 +54,8 @@ describe("Cross-Chain Native Transfer", () => {
 
         evmChainTranslator = new EvmTranslator();
         xrplChainTranslator = new XrpTranslator();
+
+        tokenContract = evmChainProvider.getERC20Contract(sourceChain.nativeToken.address);
     });
 
     describe("from evm chain to xrpl chain", () => {
@@ -61,6 +65,9 @@ describe("Cross-Chain Native Transfer", () => {
         });
 
         it("should transfer the token", async () => {
+            const totalSupplyRaw = await tokenContract.totalSupply();
+            console.log({ totalSupplyRaw });
+
             const initialSrcBalance = await evmChainProvider.getNativeBalance(evmChainWallet.address);
             const initialDestBalance = await xrplChainProvider.getNativeBalance(xrplChainWallet.address);
 
@@ -97,6 +104,9 @@ describe("Cross-Chain Native Transfer", () => {
                 (res) => !res,
                 interchainTransferOptions as PollingOptions,
             );
+
+            const totalSupplyRawafter = await tokenContract.totalSupply();
+            console.log({ totalSupplyRawafter });
         });
 
         it("should revert when transferring 0 tokens", async () => {

--- a/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
@@ -59,28 +59,28 @@ describe("Cross-Chain Native Transfer", () => {
         xrplChainTranslator = new XrpTranslator();
 
         tokenContract = evmChainProvider.getERC20Contract(sourceChain.nativeToken.address);
+
+        const totalSupplyRaw = await tokenContract.totalSupply();
+        initialTotalSupply = totalSupplyRaw.toString();
+    });
+
+    after(async () => {
+        await resetTotalSupply(
+            new Token({} as any),
+            destinationChain.interchainTokenServiceAddress,
+            sourceChain as unknown as Chain,
+            initialTotalSupply,
+            tokenContract,
+            xrplChainSigner,
+            evmChainWallet.address,
+            interchainTransferOptions,
+        );
     });
 
     describe("from evm chain to xrpl chain", () => {
         before(async () => {
             assertChainEnvironments(["devnet", "testnet", "mainnet"], config.axelar.sourceChain as unknown as AxelarBridgeChain);
             assertChainEnvironments(["devnet", "testnet", "mainnet"], config.axelar.destinationChain as unknown as AxelarBridgeChain);
-
-            const totalSupplyRaw = await tokenContract.totalSupply();
-            initialTotalSupply = totalSupplyRaw.toString();
-        });
-
-        after(async () => {
-            await resetTotalSupply(
-                sourceChain.nativeToken as Token,
-                sourceChain.door,
-                sourceChain as unknown as Chain,
-                initialTotalSupply,
-                tokenContract,
-                evmChainSigner,
-                evmChainWallet.address,
-                interchainTransferOptions,
-            );
         });
 
         it("should transfer the token", async () => {

--- a/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
@@ -66,7 +66,7 @@ describe("Cross-Chain Native Transfer", () => {
 
     after(async () => {
         await resetTotalSupply(
-            new Token({} as any),
+            destinationChain.nativeToken as Token,
             destinationChain.interchainTokenServiceAddress,
             sourceChain as unknown as Chain,
             initialTotalSupply,

--- a/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
@@ -66,7 +66,7 @@ describe("Cross-Chain Native Transfer", () => {
 
     after(async () => {
         await resetTotalSupply(
-            destinationChain.nativeToken as Token,
+            new Token({} as any),
             destinationChain.interchainTokenServiceAddress,
             sourceChain as unknown as Chain,
             initialTotalSupply,

--- a/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
+++ b/modules/axelar/test/cross-chain-transfers/xrpl-evm/native-transfer.test.ts
@@ -78,7 +78,7 @@ describe("Cross-Chain Native Transfer", () => {
     });
 
     describe("from evm chain to xrpl chain", () => {
-        before(async () => {
+        before(() => {
             assertChainEnvironments(["devnet", "testnet", "mainnet"], config.axelar.sourceChain as unknown as AxelarBridgeChain);
             assertChainEnvironments(["devnet", "testnet", "mainnet"], config.axelar.destinationChain as unknown as AxelarBridgeChain);
         });

--- a/packages/bridge/src/signers/core/error/index.ts
+++ b/packages/bridge/src/signers/core/error/index.ts
@@ -1,2 +1,3 @@
 export * from "./signer.error";
+export * from "./signer.errors";
 export * from "./is-signer-error";

--- a/packages/bridge/src/signers/core/error/signer.errors.ts
+++ b/packages/bridge/src/signers/core/error/signer.errors.ts
@@ -1,0 +1,3 @@
+export enum SignerErrors {
+    UNRECOGNIZED_SIGNER_TYPE = "Unrecognized signer type.",
+}

--- a/packages/bridge/src/signers/evm/ethers/ethers.signer.ts
+++ b/packages/bridge/src/signers/evm/ethers/ethers.signer.ts
@@ -79,7 +79,6 @@ export class EthersSigner<Provider extends IEthersSignerProvider = IEthersSigner
         const sendingAmount = new BigNumber(decimalToInt(amount, token.decimals));
 
         const interchainTokenService = this.getInterchainTokenServiceContract(doorAddress);
-        const gasValue: ethers.BigNumberish = ethers.parseUnits("0.5", "ether");
 
         const contractTx = await interchainTokenService.interchainTransfer(
             token.id!,
@@ -87,8 +86,7 @@ export class EthersSigner<Provider extends IEthersSignerProvider = IEthersSigner
             destinationAddress,
             sendingAmount.toString(),
             "0x",
-            gasValue, // BigNumberish value for gasValue
-            // { gasLimit: 300000, value: gasValue }, // and also using it for value
+            new BigNumber("100000000000000000").toString(),
         );
 
         return this.transactionParser.parseTransactionResponse(contractTx, (txReceipt) => ({

--- a/packages/bridge/src/signers/evm/ethers/ethers.signer.ts
+++ b/packages/bridge/src/signers/evm/ethers/ethers.signer.ts
@@ -79,6 +79,7 @@ export class EthersSigner<Provider extends IEthersSignerProvider = IEthersSigner
         const sendingAmount = new BigNumber(decimalToInt(amount, token.decimals));
 
         const interchainTokenService = this.getInterchainTokenServiceContract(doorAddress);
+        const gasValue: ethers.BigNumberish = ethers.parseUnits("0.5", "ether");
 
         const contractTx = await interchainTokenService.interchainTransfer(
             token.id!,
@@ -86,7 +87,8 @@ export class EthersSigner<Provider extends IEthersSignerProvider = IEthersSigner
             destinationAddress,
             sendingAmount.toString(),
             "0x",
-            new BigNumber("0").toString(),
+            gasValue, // BigNumberish value for gasValue
+            // { gasLimit: 300000, value: gasValue }, // and also using it for value
         );
 
         return this.transactionParser.parseTransactionResponse(contractTx, (txReceipt) => ({

--- a/packages/shared/evm/src/contracts/erc20.ts
+++ b/packages/shared/evm/src/contracts/erc20.ts
@@ -8,6 +8,7 @@ export const erc20Abi = [
     "function balanceOf(address account) external view returns (uint256)",
     "function approve(address spender, uint256 amount) external returns (bool)",
     "function allowance(address owner, address spender) external view returns (uint256)",
+    "function totalSupply() external view returns (uint256)",
 
     "event Transfer(address indexed from, address indexed to, uint256 value)",
 ];
@@ -22,6 +23,7 @@ export interface IERC20 extends ContractWithFilters<IERC20Filters> {
     allowance(owner: string, spender: string): Promise<ethers.BigNumberish>;
     mint(account: string, amount: ethers.BigNumberish): Promise<ethers.ContractTransaction>;
     burn(account: string, amount: ethers.BigNumberish): Promise<ethers.ContractTransaction>;
+    totalSupply(): Promise<ethers.BigNumberish>;
 }
 
 export class ERC20 extends Contract<IERC20> {

--- a/packages/testing/hardhat/package.json
+++ b/packages/testing/hardhat/package.json
@@ -15,6 +15,8 @@
         "@shared/eslint": "workspace:*",
         "@shared/tsconfig": "workspace:*",
         "@shared/evm": "workspace:*",
+        "@shared/utils": "workspace:*",
+        "@firewatch/bridge": "workspace:*",
         "chai": "^4.5.0",
         "hardhat": "^2.12.7"
     },
@@ -24,6 +26,7 @@
         "./errors": "./src/errors/index.ts"
     },
     "dependencies": {
-        "ethers": "^6.13.5"
+        "ethers": "^6.13.5",
+        "bignumber.js": "^9.1.2"
     }
 }

--- a/packages/testing/hardhat/src/constants/errors.ts
+++ b/packages/testing/hardhat/src/constants/errors.ts
@@ -1,4 +1,0 @@
-export enum HardhatErrors {
-    TRANSACTION_REVERTED = "Transaction reverted unexpectedly",
-    TRANSACTION_NOT_MINED = "Transaction receipt is null. The transaction might not have been mined yet.",
-}

--- a/packages/testing/hardhat/src/constants/index.ts
+++ b/packages/testing/hardhat/src/constants/index.ts
@@ -1,1 +1,0 @@
-export * from "./errors";

--- a/packages/testing/hardhat/src/errors/errors.ts
+++ b/packages/testing/hardhat/src/errors/errors.ts
@@ -1,3 +1,5 @@
 export enum HardhatErrors {
     UNKNOWN_CUSTOM_ERROR = "execution reverted (unknown custom error)",
+    TRANSACTION_NOT_MINED = "Transaction receipt is null. The transaction might not have been mined yet.",
+    INTERCHAIN_TRANSFER_NOT_MINTED = "Interchain transfer did not result in minted tokens as expected.",
 }

--- a/packages/testing/hardhat/src/utils/index.ts
+++ b/packages/testing/hardhat/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./transaction";
+export * from "./reset-total-supply";

--- a/packages/testing/hardhat/src/utils/reset-total-supply.ts
+++ b/packages/testing/hardhat/src/utils/reset-total-supply.ts
@@ -48,7 +48,7 @@ export async function resetTotalSupply(
 
         let destinationAddress: string;
         let tx: Unconfirmed<EthersTransaction> | Unconfirmed<XrplTransaction>;
-        const amountToBridgeIn = ethers.formatUnits(amountToBridgeInRaw.toString(), token.decimals);
+        const amountToBridgeIn = ethers.formatUnits(amountToBridgeInRaw.toString(), 18);
 
         if (signer instanceof EthersSigner) {
             destinationAddress = xrplEvmWalletAddress;

--- a/packages/testing/hardhat/src/utils/reset-total-supply.ts
+++ b/packages/testing/hardhat/src/utils/reset-total-supply.ts
@@ -9,6 +9,7 @@ import { XrpTranslator } from "@firewatch/bridge/translators/xrp";
 import { SignerErrors } from "@firewatch/bridge/signers/error";
 import { polling, PollingOptions } from "@shared/utils";
 import { HardhatErrors } from "../errors";
+import { ethers } from "ethers";
 
 /**
  * Resets the total token supply on a blockchain by bridging in the missing tokens.
@@ -39,14 +40,15 @@ export async function resetTotalSupply(
 
         const currentTotalSupply = new BigNumber(totalSupplyRaw.toString());
         const initSupply = new BigNumber(initialTotalSupply);
-        const amountToBridgeIn = initSupply.minus(currentTotalSupply);
+        const amountToBridgeInRaw = initSupply.minus(currentTotalSupply);
 
-        if (amountToBridgeIn.lte(0)) {
+        if (amountToBridgeInRaw.lte(0)) {
             return;
         }
 
         let destinationAddress: string;
         let tx: Unconfirmed<EthersTransaction> | Unconfirmed<XrplTransaction>;
+        const amountToBridgeIn = ethers.formatUnits(amountToBridgeInRaw.toString(), token.decimals);
 
         if (signer instanceof EthersSigner) {
             destinationAddress = xrplEvmWalletAddress;

--- a/packages/testing/hardhat/src/utils/reset-total-supply.ts
+++ b/packages/testing/hardhat/src/utils/reset-total-supply.ts
@@ -1,0 +1,79 @@
+import { Token } from "@firewatch/core/token";
+import { EthersSigner, EthersTransaction } from "../../../../bridge/src/signers/evm/ethers";
+import { XrplSigner, XrplTransaction } from "../../../../bridge/src/signers/xrp/xrpl";
+import { ERC20 } from "@shared/evm/contracts";
+import { Unconfirmed } from "@shared/modules/blockchain";
+import BigNumber from "bignumber.js";
+import { Chain } from "@firewatch/core/chain";
+import { XrpTranslator } from "@firewatch/bridge/translators/xrp";
+import { SignerErrors } from "@firewatch/bridge/signers/error";
+import { polling, PollingOptions } from "@shared/utils";
+import { HardhatErrors } from "../errors";
+
+/**
+ * Resets the total token supply on a blockchain by bridging in the missing tokens.
+ * It calculates the missing amount by comparing the initial total supply with the current supply,
+ * and then bridges in the missing tokens using the appropriate signer (EVM or XRPL).
+ * @param token - The token for which the total supply is being reset.
+ * @param sourceDoorAddress - The door address to use for the transfer.
+ * @param xrplEvmChain - The target chain details where tokens should be bridged in.
+ * @param initialTotalSupply - The initial total supply (in raw value matching the contract's units).
+ * @param tokenContract - The ERC20 token contract instance.
+ * @param signer - The signer instance (EthersSigner or XrplSigner) used for transferring tokens.
+ * @param xrplEvmWalletAddress - The wallet address on the EVM chain (used for translation in case of EVM signer).
+ * @param interchainTransferOptions - Polling options used to verify that the total supply has been updated.
+ * @returns A promise that resolves to an Unconfirmed transaction (EVM or XRPL) representing the bridging in transfer.
+ */
+export async function resetTotalSupply(
+    token: Token,
+    sourceDoorAddress: string,
+    xrplEvmChain: Chain,
+    initialTotalSupply: string,
+    tokenContract: ERC20,
+    signer: EthersSigner | XrplSigner,
+    xrplEvmWalletAddress: string,
+    interchainTransferOptions: PollingOptions,
+): Promise<Unconfirmed<EthersTransaction> | Unconfirmed<XrplTransaction> | undefined> {
+    try {
+        const totalSupplyRaw = await tokenContract.totalSupply();
+
+        const currentTotalSupply = new BigNumber(totalSupplyRaw.toString());
+        const initSupply = new BigNumber(initialTotalSupply);
+        const amountToBridgeIn = initSupply.minus(currentTotalSupply);
+
+        if (amountToBridgeIn.lte(0)) {
+            return;
+        }
+
+        let destinationAddress: string;
+        let tx: Unconfirmed<EthersTransaction> | Unconfirmed<XrplTransaction>;
+
+        if (signer instanceof EthersSigner) {
+            const xrplChainTranslator = new XrpTranslator();
+            destinationAddress = xrplChainTranslator.translate(xrplEvmChain.type, xrplEvmWalletAddress);
+            tx = await signer.transfer(amountToBridgeIn.toString(), token, sourceDoorAddress, xrplEvmChain.id, destinationAddress);
+        } else if (signer instanceof XrplSigner) {
+            destinationAddress = xrplEvmWalletAddress;
+            tx = await signer.transfer(amountToBridgeIn.toString(), token, sourceDoorAddress, xrplEvmChain.id, destinationAddress);
+        } else {
+            throw new Error(SignerErrors.UNRECOGNIZED_SIGNER_TYPE);
+        }
+
+        try {
+            await polling(
+                async () => {
+                    const totalSupply = await tokenContract.totalSupply();
+                    return new BigNumber(totalSupply.toString()).eq(initSupply);
+                },
+                (result) => !result,
+                interchainTransferOptions,
+            );
+        } catch (pollingError) {
+            throw new Error(HardhatErrors.INTERCHAIN_TRANSFER_NOT_MINTED);
+        }
+
+        return tx;
+    } catch (error) {
+        throw error;
+    }
+}

--- a/packages/testing/hardhat/src/utils/reset-total-supply.ts
+++ b/packages/testing/hardhat/src/utils/reset-total-supply.ts
@@ -49,11 +49,11 @@ export async function resetTotalSupply(
         let tx: Unconfirmed<EthersTransaction> | Unconfirmed<XrplTransaction>;
 
         if (signer instanceof EthersSigner) {
-            const xrplChainTranslator = new XrpTranslator();
-            destinationAddress = xrplChainTranslator.translate(xrplEvmChain.type, xrplEvmWalletAddress);
+            destinationAddress = xrplEvmWalletAddress;
             tx = await signer.transfer(amountToBridgeIn.toString(), token, sourceDoorAddress, xrplEvmChain.id, destinationAddress);
         } else if (signer instanceof XrplSigner) {
-            destinationAddress = xrplEvmWalletAddress;
+            const xrplChainTranslator = new XrpTranslator();
+            destinationAddress = xrplChainTranslator.translate(xrplEvmChain.type, xrplEvmWalletAddress);
             tx = await signer.transfer(amountToBridgeIn.toString(), token, sourceDoorAddress, xrplEvmChain.id, destinationAddress);
         } else {
             throw new Error(SignerErrors.UNRECOGNIZED_SIGNER_TYPE);

--- a/packages/testing/hardhat/src/utils/transaction.ts
+++ b/packages/testing/hardhat/src/utils/transaction.ts
@@ -1,6 +1,6 @@
 import { TransactionReceipt, TransactionResponse, ContractTransactionResponse } from "ethers";
 import { Unconfirmed, Transaction } from "@shared/modules/blockchain";
-import { HardhatErrors } from "../constants";
+import { HardhatErrors } from "../errors";
 
 type TxPromise = Promise<Unconfirmed<Transaction>> | Promise<ContractTransactionResponse>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,10 +114,10 @@ importers:
     dependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.8
-        version: 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(pc3fqpajp45nwt6d3qppa4n7vu)
+        version: 5.0.0(qv34j4znhz3hqps6zs5pfdctrm)
       chai:
         specifier: ^4.5.0
         version: 4.5.0
@@ -126,7 +126,7 @@ importers:
         version: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat:
         specifier: ^2.22.18
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
     devDependencies:
       '@firewatch/core':
         specifier: workspace:*
@@ -450,19 +450,25 @@ importers:
 
   packages/testing/hardhat:
     dependencies:
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       ethers:
         specifier: ^6.13.5
         version: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
     devDependencies:
+      '@firewatch/bridge':
+        specifier: workspace:*
+        version: link:../../bridge
       '@firewatch/core':
         specifier: workspace:*
         version: link:../../core
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.2
-        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-waffle':
         specifier: ^2.0.3
-        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@shared/eslint':
         specifier: workspace:*
         version: link:../../shared/eslint
@@ -475,12 +481,15 @@ importers:
       '@shared/tsconfig':
         specifier: workspace:*
         version: link:../../shared/tsconfig
+      '@shared/utils':
+        specifier: workspace:*
+        version: link:../../shared/utils
       chai:
         specifier: ^4.5.0
         version: 4.5.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   packages/testing/mocha:
     dependencies:
@@ -2013,11 +2022,11 @@ packages:
   '@types/node@11.11.6':
     resolution: {integrity: sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==}
 
-  '@types/node@22.13.10':
-    resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
-
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -5543,6 +5552,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@5.28.5:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
@@ -7313,17 +7325,6 @@ snapshots:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
-  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
-    dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      '@types/chai-as-promised': 7.1.8
-      chai: 4.5.0
-      chai-as-promised: 7.1.2(chai@4.5.0)
-      deep-eql: 4.1.4
-      ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      ordinal: 1.0.3
-
   '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
       '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
@@ -7335,14 +7336,16 @@ snapshots:
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
       ordinal: 1.0.3
 
-  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@types/chai-as-promised': 7.1.8
+      chai: 4.5.0
+      chai-as-promised: 7.1.2(chai@4.5.0)
+      deep-eql: 4.1.4
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      lodash.isequal: 4.5.0
-    transitivePeerDependencies:
-      - supports-color
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      ordinal: 1.0.3
 
   '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -7353,13 +7356,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nomicfoundation/hardhat-ignition-ethers@0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-ignition': 0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
-      '@nomicfoundation/ignition-core': 0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+      debug: 4.4.0(supports-color@8.1.1)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      lodash.isequal: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@nomicfoundation/hardhat-ignition-ethers@0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -7369,21 +7373,13 @@ snapshots:
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
-  '@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)':
+  '@nomicfoundation/hardhat-ignition-ethers@0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ignition': 0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
       '@nomicfoundation/ignition-core': 0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      '@nomicfoundation/ignition-ui': 0.15.9
-      chalk: 4.1.2
-      debug: 4.4.0(supports-color@8.1.1)
-      fs-extra: 10.1.0
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      json5: 2.2.3
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
+      ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   '@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)':
     dependencies:
@@ -7401,15 +7397,31 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)':
     dependencies:
-      ethereumjs-util: 7.1.5
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/ignition-core': 0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+      '@nomicfoundation/ignition-ui': 0.15.9
+      chalk: 4.1.2
+      debug: 4.4.0(supports-color@8.1.1)
+      fs-extra: 10.1.0
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      json5: 2.2.3
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethereumjs-util: 7.1.5
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+
+  '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+    dependencies:
+      ethereumjs-util: 7.1.5
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   '@nomicfoundation/hardhat-toolbox@5.0.0(ktbqv4ygttp7focgrbrq332mmm)':
     dependencies:
@@ -7432,41 +7444,26 @@ snapshots:
       typechain: 8.3.2(typescript@5.7.3)
       typescript: 5.7.3
 
-  '@nomicfoundation/hardhat-toolbox@5.0.0(pc3fqpajp45nwt6d3qppa4n7vu)':
+  '@nomicfoundation/hardhat-toolbox@5.0.0(qv34j4znhz3hqps6zs5pfdctrm)':
     dependencies:
-      '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-ignition-ethers': 0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ignition-ethers': 0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3)
-      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))
       '@types/chai': 5.0.1
       '@types/mocha': 10.0.10
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
       chai: 4.5.0
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      hardhat-gas-reporter: 1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
-      solidity-coverage: 0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
-      ts-node: 10.9.2(@types/node@22.13.10)(typescript@5.7.3)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat-gas-reporter: 1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
+      solidity-coverage: 0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.3)
       typechain: 8.3.2(typescript@5.7.3)
       typescript: 5.7.3
-
-  '@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/address': 5.7.0
-      cbor: 8.1.0
-      debug: 4.4.0(supports-color@8.1.1)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      lodash.clonedeep: 4.5.0
-      picocolors: 1.1.1
-      semver: 6.3.1
-      table: 6.9.0
-      undici: 5.28.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -7475,6 +7472,21 @@ snapshots:
       cbor: 8.1.0
       debug: 4.4.0(supports-color@8.1.1)
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      lodash.clonedeep: 4.5.0
+      picocolors: 1.1.1
+      semver: 6.3.1
+      table: 6.9.0
+      undici: 5.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/address': 5.7.0
+      cbor: 8.1.0
+      debug: 4.4.0(supports-color@8.1.1)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
       semver: 6.3.1
@@ -7532,18 +7544,18 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@types/sinon-chai': 3.2.12
       ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   '@peersyst/xrp-evm-contracts@2.1.1(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -8057,20 +8069,20 @@ snapshots:
       typechain: 8.3.2(typescript@5.7.3)
       typescript: 5.7.3
 
-  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))':
-    dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3)
-      ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      fs-extra: 9.1.0
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      typechain: 8.3.2(typescript@5.7.3)
-
   '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))':
     dependencies:
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       fs-extra: 9.1.0
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      typechain: 8.3.2(typescript@5.7.3)
+
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))':
+    dependencies:
+      '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.7.3))(typescript@5.7.3)
+      ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+      fs-extra: 9.1.0
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
       typechain: 8.3.2(typescript@5.7.3)
 
   '@types/abstract-leveldown@7.2.5': {}
@@ -8114,7 +8126,7 @@ snapshots:
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/deep-eql@4.0.2': {}
 
@@ -8122,12 +8134,12 @@ snapshots:
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -8156,7 +8168,7 @@ snapshots:
     dependencies:
       '@types/abstract-leveldown': 7.2.5
       '@types/level-errors': 3.0.2
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/lru-cache@5.1.1': {}
 
@@ -8164,26 +8176,26 @@ snapshots:
 
   '@types/mkdirp@0.5.2':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/mocha@10.0.10': {}
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
       form-data: 4.0.2
 
   '@types/node@10.17.60': {}
 
   '@types/node@11.11.6': {}
 
-  '@types/node@22.13.10':
-    dependencies:
-      undici-types: 6.20.0
-
   '@types/node@22.13.4':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.7.5':
     dependencies:
@@ -9325,7 +9337,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9346,7 +9358,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10038,18 +10050,6 @@ snapshots:
       ajv: 6.12.6
       har-schema: 2.0.0
 
-  hardhat-gas-reporter@1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7):
-    dependencies:
-      array-uniq: 1.0.3
-      eth-gas-reporter: 0.2.27(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      sha1: 1.1.1
-    transitivePeerDependencies:
-      - '@codechecks/client'
-      - bufferutil
-      - debug
-      - utf-8-validate
-
   hardhat-gas-reporter@1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7):
     dependencies:
       array-uniq: 1.0.3
@@ -10062,59 +10062,16 @@ snapshots:
       - debug
       - utf-8-validate
 
-  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
+  hardhat-gas-reporter@1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7):
     dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/edr': 0.7.0
-      '@nomicfoundation/ethereumjs-common': 4.0.4
-      '@nomicfoundation/ethereumjs-tx': 5.0.4
-      '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomicfoundation/solidity-analyzer': 0.1.2
-      '@sentry/node': 5.30.0
-      '@types/bn.js': 5.1.6
-      '@types/lru-cache': 5.1.1
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      boxen: 5.1.2
-      chokidar: 4.0.3
-      ci-info: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
-      enquirer: 2.4.1
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      ethereumjs-abi: 0.6.8
-      find-up: 5.0.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      immutable: 4.3.7
-      io-ts: 1.10.4
-      json-stream-stringify: 3.1.6
-      keccak: 3.0.4
-      lodash: 4.17.21
-      mnemonist: 0.38.5
-      mocha: 10.8.2
-      p-map: 4.0.0
-      picocolors: 1.1.1
-      raw-body: 2.5.2
-      resolve: 1.17.0
-      semver: 6.3.1
-      solc: 0.8.26(debug@4.4.0)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.11
-      tsort: 0.0.1
-      undici: 5.28.5
-      uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-    optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.13.10)(typescript@5.7.3)
-      typescript: 5.7.3
+      array-uniq: 1.0.3
+      eth-gas-reporter: 0.2.27(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      sha1: 1.1.1
     transitivePeerDependencies:
+      - '@codechecks/client'
       - bufferutil
-      - c-kzg
-      - supports-color
+      - debug
       - utf-8-validate
 
   hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
@@ -10165,6 +10122,61 @@ snapshots:
       ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
     optionalDependencies:
       ts-node: 10.9.2(@types/node@22.13.4)(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - c-kzg
+      - supports-color
+      - utf-8-validate
+
+  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@metamask/eth-sig-util': 4.0.1
+      '@nomicfoundation/edr': 0.7.0
+      '@nomicfoundation/ethereumjs-common': 4.0.4
+      '@nomicfoundation/ethereumjs-tx': 5.0.4
+      '@nomicfoundation/ethereumjs-util': 9.0.4
+      '@nomicfoundation/solidity-analyzer': 0.1.2
+      '@sentry/node': 5.30.0
+      '@types/bn.js': 5.1.6
+      '@types/lru-cache': 5.1.1
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chokidar: 4.0.3
+      ci-info: 2.0.0
+      debug: 4.4.0(supports-color@8.1.1)
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      ethereumjs-abi: 0.6.8
+      find-up: 5.0.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      immutable: 4.3.7
+      io-ts: 1.10.4
+      json-stream-stringify: 3.1.6
+      keccak: 3.0.4
+      lodash: 4.17.21
+      mnemonist: 0.38.5
+      mocha: 10.8.2
+      p-map: 4.0.0
+      picocolors: 1.1.1
+      raw-body: 2.5.2
+      resolve: 1.17.0
+      semver: 6.3.1
+      solc: 0.8.26(debug@4.4.0)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      tinyglobby: 0.2.11
+      tsort: 0.0.1
+      undici: 5.28.5
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - bufferutil
@@ -11981,29 +11993,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solidity-coverage@0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)):
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@solidity-parser/parser': 0.19.0
-      chalk: 2.4.2
-      death: 1.1.0
-      difflib: 0.2.4
-      fs-extra: 8.1.0
-      ghost-testrpc: 0.0.2
-      global-modules: 2.0.0
-      globby: 10.0.2
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
-      jsonschema: 1.5.0
-      lodash: 4.17.21
-      mocha: 10.8.2
-      node-emoji: 1.11.0
-      pify: 4.0.1
-      recursive-readdir: 2.2.3
-      sc-istanbul: 0.4.6
-      semver: 7.7.1
-      shelljs: 0.8.5
-      web3-utils: 1.10.4
-
   solidity-coverage@0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)):
     dependencies:
       '@ethersproject/abi': 5.7.0
@@ -12016,6 +12005,29 @@ snapshots:
       global-modules: 2.0.0
       globby: 10.0.2
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      jsonschema: 1.5.0
+      lodash: 4.17.21
+      mocha: 10.8.2
+      node-emoji: 1.11.0
+      pify: 4.0.1
+      recursive-readdir: 2.2.3
+      sc-istanbul: 0.4.6
+      semver: 7.7.1
+      shelljs: 0.8.5
+      web3-utils: 1.10.4
+
+  solidity-coverage@0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)):
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@solidity-parser/parser': 0.19.0
+      chalk: 2.4.2
+      death: 1.1.0
+      difflib: 0.2.4
+      fs-extra: 8.1.0
+      ghost-testrpc: 0.0.2
+      global-modules: 2.0.0
+      globby: 10.0.2
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
       jsonschema: 1.5.0
       lodash: 4.17.21
       mocha: 10.8.2
@@ -12380,14 +12392,14 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.9)
       esbuild: 0.24.2
 
-  ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.13.10
+      '@types/node': 22.13.4
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -12398,14 +12410,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.13.4
+      '@types/node': 22.14.0
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -12582,6 +12594,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
+
+  undici-types@6.21.0: {}
 
   undici@5.28.5:
     dependencies:


### PR DESCRIPTION
# [TA-4279]: Add Cleanup to Axelar tests

## Changes :hammer_and_wrench:

### modules/axelar

- Add cleanup functionality through before and after hooks and resetTotalSupply function.

### packages/testing/hardhat

- Add resetTotalSupply, calculates totalSupply from an ERC20, takes previous totalSupply, bridges the difference.
- Unify HH errors, before split between `constants/errors.ts` and `errors/errors.ts`


