### PR TITLE
[TA-4278]: Cleanup to ERC20 tests

### DIFF
--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -36,8 +36,8 @@
             ],
             "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
-            "amount": "1",
-            "feeFund": "1000000000000000000",
+            "minimumAmount": "1",
+            "faucetFund": "1000000000000000000",
             "gasPrice": "253125000000"
         }
     },

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -6,8 +6,8 @@
             "xrplevm_testnet": {
                 "url": "https://rpc.testnet.xrplevm.org",
                 "accounts": [
-                    "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9",
-                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100"
+                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100",
+                    "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9"
                 ]
             }
         }

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -39,9 +39,7 @@
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000",
-            "avgGasPrice": "253125000000",
-            "approveGasUsed": "52624",
-            "correctionFactor": "0.999"
+            "correctionFactor": "0.8"
         }
     },
     "chain": {

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -39,7 +39,8 @@
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000",
-            "correctionFactor": "0.8"
+            "feeMultiplier": "0.95",
+            "residualThreshold": "0.8"
         }
     },
     "chain": {

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -36,9 +36,12 @@
             ],
             "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
-            "minimumAmount": "1",
-            "faucetFund": "1000000000000000000",
-            "gasPrice": "253125000000"
+            "amount": "1",
+            "burnAmount": "1",
+            "faucetFund": "10000000000000000000",
+            "avgGasPrice": "253125000000",
+            "approveGasUsed": "52624",
+            "correctionFactor": "0.999"
         }
     },
     "chain": {

--- a/modules/evm/module.config.example.json
+++ b/modules/evm/module.config.example.json
@@ -37,7 +37,8 @@
             "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
             "amount": "1",
-            "feeFund": "10000000"
+            "feeFund": "1000000000000000000",
+            "gasPrice": "253125000000"
         }
     },
     "chain": {

--- a/modules/evm/package.json
+++ b/modules/evm/package.json
@@ -13,6 +13,7 @@
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "chai": "^4.5.0",
         "ethers": "^6.13.5",
+        "bignumber.js": "^9.1.2",
         "hardhat": "^2.22.18"
     },
     "devDependencies": {

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -107,16 +107,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should mint tokens to the user", async () => {
@@ -170,16 +161,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should revert if sender is not owner", async () => {
@@ -204,16 +186,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should revert if spender does not have allowance", async () => {
@@ -246,16 +219,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should revert if sender is not the owner", async () => {
@@ -274,16 +238,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should correctly increase allowance", async () => {
@@ -302,16 +257,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should successfully transfer tokens between accounts", async () => {
@@ -344,16 +290,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should successfully transfer tokens using transferFrom", async () => {
@@ -397,16 +334,7 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(
-                ownerContract,
-                userContract,
-                ownerSigner,
-                userSigner,
-                chain.env,
-                erc20.avgGasPrice,
-                erc20.approveGasUsed,
-                erc20.correctionFactor,
-            );
+            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
         });
 
         it("should set and reset the allowance correctly and emit Approval events", async () => {

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -58,8 +58,7 @@ describe("ERC20", () => {
     afterEach(async () => {
         if (chain.env === "localnet") {
             await resetLocalnetOwnerState(ownerContract, userContract, ownerSigner, userSigner);
-        }
-        {
+        } else {
             await resetLivenetOwnerState(ownerContract, userContract, ownerSigner, userSigner, erc20.gasPrice);
         }
     });

--- a/modules/evm/test/precompiles/erc20/index.test.ts
+++ b/modules/evm/test/precompiles/erc20/index.test.ts
@@ -107,7 +107,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should mint tokens to the user", async () => {
@@ -161,7 +169,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should revert if sender is not owner", async () => {
@@ -186,7 +202,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should revert if spender does not have allowance", async () => {
@@ -219,7 +243,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should revert if sender is not the owner", async () => {
@@ -238,7 +270,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should correctly increase allowance", async () => {
@@ -257,7 +297,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should successfully transfer tokens between accounts", async () => {
@@ -290,7 +338,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should successfully transfer tokens using transferFrom", async () => {
@@ -334,7 +390,15 @@ describe("ERC20", () => {
             await executeTx(userContract.transfer(ownerSigner.address, erc20.faucetFund));
         });
         afterEach(async () => {
-            await resetOwnerState(ownerContract, userContract, ownerSigner, userSigner, chain.env, erc20.correctionFactor);
+            await resetOwnerState(
+                ownerContract,
+                userContract,
+                ownerSigner,
+                userSigner,
+                chain.env,
+                erc20.feeMultiplier,
+                erc20.residualThreshold,
+            );
         });
 
         it("should set and reset the allowance correctly and emit Approval events", async () => {

--- a/modules/evm/test/precompiles/erc20/utils/helpers.ts
+++ b/modules/evm/test/precompiles/erc20/utils/helpers.ts
@@ -25,7 +25,7 @@ export async function resetLocalnetOwnerState(
         const exactApprovalAmount: bigint = ownerBalance - burnGasEstimate;
 
         await executeTx(ownerContract.approve(userSigner.address, exactApprovalAmount));
-        await executeTx(userContract.burnFrom(ownerSigner.address, exactApprovalAmount));
+        await executeTx(userContract.transferFrom(ownerSigner.address, userSigner.address, exactApprovalAmount));
 
         const ownerBalanceAfterBurn: bigint = await ownerContract.balanceOf(ownerSigner.address);
         const allowanceAfterBurn: bigint = await ownerContract.allowance(ownerSigner.address, userSigner.address);
@@ -60,14 +60,15 @@ export async function resetLivenetOwnerState(
         const adjustedGasEstimate = new BigNumber(gasEstimate.toString()).multipliedBy(1.0005).integerValue(BigNumber.ROUND_CEIL);
         const priceBN = new BigNumber(gasPrice);
         const cost = adjustedGasEstimate.multipliedBy(priceBN);
-        const burnAmount: bigint = ownerBalanceBefore - BigInt(cost.toFixed(0));
+        const finalCost = BigInt(cost.toFixed(0));
+        const transferAmount: bigint = ownerBalanceBefore - finalCost;
 
-        if (burnAmount < 0n) {
+        if (transferAmount < 0n) {
             return;
         }
 
-        await executeTx(ownerContract.approve(userSigner.address, burnAmount));
-        await executeTx(userContract.burnFrom(ownerSigner.address, burnAmount));
+        await executeTx(ownerContract.approve(userSigner.address, transferAmount));
+        await executeTx(userContract.transferFrom(ownerSigner.address, userSigner.address, transferAmount));
 
         const ownerBalanceAfter: bigint = await ownerContract.balanceOf(ownerSigner.address);
         const remainingAllowance: bigint = await ownerContract.allowance(ownerSigner.address, userSigner.address);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
         version: 5.0.0(pc3fqpajp45nwt6d3qppa4n7vu)
-      bignumber.js:
-        specifier: ^9.1.2
-        version: 9.1.2
       chai:
         specifier: ^4.5.0
         version: 4.5.0
@@ -462,10 +459,10 @@ importers:
         version: link:../../core
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.2
-        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-waffle':
         specifier: ^2.0.3
-        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@shared/eslint':
         specifier: workspace:*
         version: link:../../shared/eslint
@@ -483,7 +480,7 @@ importers:
         version: 4.5.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   packages/testing/mocha:
     dependencies:
@@ -2021,9 +2018,6 @@ packages:
 
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
-
-  '@types/node@22.14.1':
-    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -5549,9 +5543,6 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici@5.28.5:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
@@ -7541,18 +7532,18 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@types/sinon-chai': 3.2.12
       ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   '@peersyst/xrp-evm-contracts@2.1.1(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -8123,7 +8114,7 @@ snapshots:
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.13.10
 
   '@types/deep-eql@4.0.2': {}
 
@@ -8131,12 +8122,12 @@ snapshots:
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.13.10
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.14.1
+      '@types/node': 22.13.10
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -8165,7 +8156,7 @@ snapshots:
     dependencies:
       '@types/abstract-leveldown': 7.2.5
       '@types/level-errors': 3.0.2
-      '@types/node': 22.14.1
+      '@types/node': 22.13.10
 
   '@types/lru-cache@5.1.1': {}
 
@@ -8173,13 +8164,13 @@ snapshots:
 
   '@types/mkdirp@0.5.2':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.13.10
 
   '@types/mocha@10.0.10': {}
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.13.10
       form-data: 4.0.2
 
   '@types/node@10.17.60': {}
@@ -8193,10 +8184,6 @@ snapshots:
   '@types/node@22.13.4':
     dependencies:
       undici-types: 6.20.0
-
-  '@types/node@22.14.1':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.7.5':
     dependencies:
@@ -9338,7 +9325,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9359,7 +9346,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10178,61 +10165,6 @@ snapshots:
       ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
     optionalDependencies:
       ts-node: 10.9.2(@types/node@22.13.4)(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - bufferutil
-      - c-kzg
-      - supports-color
-      - utf-8-validate
-
-  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@metamask/eth-sig-util': 4.0.1
-      '@nomicfoundation/edr': 0.7.0
-      '@nomicfoundation/ethereumjs-common': 4.0.4
-      '@nomicfoundation/ethereumjs-tx': 5.0.4
-      '@nomicfoundation/ethereumjs-util': 9.0.4
-      '@nomicfoundation/solidity-analyzer': 0.1.2
-      '@sentry/node': 5.30.0
-      '@types/bn.js': 5.1.6
-      '@types/lru-cache': 5.1.1
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      boxen: 5.1.2
-      chokidar: 4.0.3
-      ci-info: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
-      enquirer: 2.4.1
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      ethereumjs-abi: 0.6.8
-      find-up: 5.0.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      immutable: 4.3.7
-      io-ts: 1.10.4
-      json-stream-stringify: 3.1.6
-      keccak: 3.0.4
-      lodash: 4.17.21
-      mnemonist: 0.38.5
-      mocha: 10.8.2
-      p-map: 4.0.0
-      picocolors: 1.1.1
-      raw-body: 2.5.2
-      resolve: 1.17.0
-      semver: 6.3.1
-      solc: 0.8.26(debug@4.4.0)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.11
-      tsort: 0.0.1
-      undici: 5.28.5
-      uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-    optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.14.1)(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - bufferutil
@@ -12484,25 +12416,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.14.1
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.7.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -12669,8 +12582,6 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
-
-  undici-types@6.21.0: {}
 
   undici@5.28.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
         version: 5.0.0(pc3fqpajp45nwt6d3qppa4n7vu)
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       chai:
         specifier: ^4.5.0
         version: 4.5.0
@@ -459,10 +462,10 @@ importers:
         version: link:../../core
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.2
-        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-waffle':
         specifier: ^2.0.3
-        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@shared/eslint':
         specifier: workspace:*
         version: link:../../shared/eslint
@@ -480,7 +483,7 @@ importers:
         version: 4.5.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   packages/testing/mocha:
     dependencies:
@@ -2018,6 +2021,9 @@ packages:
 
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -5543,6 +5549,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@5.28.5:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
@@ -7532,18 +7541,18 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@types/sinon-chai': 3.2.12
       ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   '@peersyst/xrp-evm-contracts@2.1.1(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -8114,7 +8123,7 @@ snapshots:
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/deep-eql@4.0.2': {}
 
@@ -8122,12 +8131,12 @@ snapshots:
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -8156,7 +8165,7 @@ snapshots:
     dependencies:
       '@types/abstract-leveldown': 7.2.5
       '@types/level-errors': 3.0.2
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/lru-cache@5.1.1': {}
 
@@ -8164,13 +8173,13 @@ snapshots:
 
   '@types/mkdirp@0.5.2':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
 
   '@types/mocha@10.0.10': {}
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.14.0
       form-data: 4.0.2
 
   '@types/node@10.17.60': {}
@@ -8184,6 +8193,10 @@ snapshots:
   '@types/node@22.13.4':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.7.5':
     dependencies:
@@ -9325,7 +9338,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9346,7 +9359,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10165,6 +10178,61 @@ snapshots:
       ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
     optionalDependencies:
       ts-node: 10.9.2(@types/node@22.13.4)(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - c-kzg
+      - supports-color
+      - utf-8-validate
+
+  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@metamask/eth-sig-util': 4.0.1
+      '@nomicfoundation/edr': 0.7.0
+      '@nomicfoundation/ethereumjs-common': 4.0.4
+      '@nomicfoundation/ethereumjs-tx': 5.0.4
+      '@nomicfoundation/ethereumjs-util': 9.0.4
+      '@nomicfoundation/solidity-analyzer': 0.1.2
+      '@sentry/node': 5.30.0
+      '@types/bn.js': 5.1.6
+      '@types/lru-cache': 5.1.1
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      boxen: 5.1.2
+      chokidar: 4.0.3
+      ci-info: 2.0.0
+      debug: 4.4.0(supports-color@8.1.1)
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      ethereum-cryptography: 1.2.0
+      ethereumjs-abi: 0.6.8
+      find-up: 5.0.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      immutable: 4.3.7
+      io-ts: 1.10.4
+      json-stream-stringify: 3.1.6
+      keccak: 3.0.4
+      lodash: 4.17.21
+      mnemonist: 0.38.5
+      mocha: 10.8.2
+      p-map: 4.0.0
+      picocolors: 1.1.1
+      raw-body: 2.5.2
+      resolve: 1.17.0
+      semver: 6.3.1
+      solc: 0.8.26(debug@4.4.0)
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      tinyglobby: 0.2.11
+      tsort: 0.0.1
+      undici: 5.28.5
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - bufferutil
@@ -12416,6 +12484,25 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.14.0
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -12582,6 +12669,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
+
+  undici-types@6.21.0: {}
 
   undici@5.28.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,10 +462,10 @@ importers:
         version: link:../../core
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.2
-        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-waffle':
         specifier: ^2.0.3
-        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@shared/eslint':
         specifier: workspace:*
         version: link:../../shared/eslint
@@ -483,7 +483,7 @@ importers:
         version: 4.5.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   packages/testing/mocha:
     dependencies:
@@ -2022,8 +2022,8 @@ packages:
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
 
-  '@types/node@22.14.0':
-    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
+  '@types/node@22.14.1':
+    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -7541,18 +7541,18 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))
       '@types/sinon-chai': 3.2.12
       ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.7.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7)
 
   '@peersyst/xrp-evm-contracts@2.1.1(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -8123,7 +8123,7 @@ snapshots:
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/deep-eql@4.0.2': {}
 
@@ -8131,12 +8131,12 @@ snapshots:
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -8165,7 +8165,7 @@ snapshots:
     dependencies:
       '@types/abstract-leveldown': 7.2.5
       '@types/level-errors': 3.0.2
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/lru-cache@5.1.1': {}
 
@@ -8173,13 +8173,13 @@ snapshots:
 
   '@types/mkdirp@0.5.2':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
 
   '@types/mocha@10.0.10': {}
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
       form-data: 4.0.2
 
   '@types/node@10.17.60': {}
@@ -8194,7 +8194,7 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/node@22.14.0':
+  '@types/node@22.14.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -10185,7 +10185,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
+  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3))(typescript@5.7.3)(utf-8-validate@5.0.7):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -10232,7 +10232,7 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.14.0)(typescript@5.7.3)
+      ts-node: 10.9.2(@types/node@22.14.1)(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - bufferutil
@@ -12484,14 +12484,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.14.0)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@22.14.1)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.14.0
+      '@types/node': 22.14.1
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
# [TA-4278]: Cleanup to ERC20 tests

## Changes :hammer_and_wrench:

### modules/evm

- Add resetLivenetOwnerState helper: sets acc1 (user) as faucet and acc2 (owner) with a clean state. Since the ERC20 acts as the native token, only approximate calculations are possible, and the state gets close to 0 (but not exactly).
- Renamed resetOwnerState to resetLocalnetOwnerState.

### Notes
- ehavior changed: instead of burning tokens to reset owner state, now it transfers them to the faucet.
Burning is probably more accurate, but I don't see the need to keep burning tokens—especially if this runs on mainnet. Let me know what you think @GuillemGarciaDev.
- This branch is based on `test-query-erc20`, so merge that one first.
