### PR TITLE
[TA-5978]: test rpc calls with pre upgrade transactions & blocks

### DIFF
--- a/modules/evm/.env.example
+++ b/modules/evm/.env.example
@@ -2,3 +2,19 @@ AWS_REGION=your-region
 AWS_APP_CONFIG_APP=app-id
 AWS_APP_CONFIG_ENV=env-id
 AWS_APP_CONFIG_PROFILE=profile-id
+
+# Testnet RPC Credentials
+XRPLEVM_TESTNET_RPC_USERNAME=your_testnet_username
+XRPLEVM_TESTNET_RPC_PASSWORD=your_testnet_password
+
+# Devnet RPC Credentials (optional)
+XRPLEVM_DEVNET_RPC_USERNAME=your_devnet_username
+XRPLEVM_DEVNET_RPC_PASSWORD=your_devnet_password
+
+# Mainnet RPC Credentials (optional)
+XRPLEVM_MAINNET_RPC_USERNAME=your_mainnet_username
+XRPLEVM_MAINNET_RPC_PASSWORD=your_mainnet_password
+
+# Localnet RPC Credentials (optional)
+XRPLEVM_LOCALNET_RPC_USERNAME=your_localnet_username
+XRPLEVM_LOCALNET_RPC_PASSWORD=your_localnet_password

--- a/modules/evm/configs/devnet.module.config.json
+++ b/modules/evm/configs/devnet.module.config.json
@@ -39,7 +39,44 @@
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
-        }
+        },
+        "rpc": [
+            {
+                "label": "v9.0.0",
+                "block": {
+                    "number": 21158660,
+                    "hash": "0x90864febaf829431f133302877128e3e4c7c214a4d050b29d5dcd3d8b50c07d6"
+                },
+                "transaction": {
+                    "hash": "0x19f98122077c54ea8be201c987a5772565214da43d4ec806cd371772db7bd3e0",
+                    "index": 0
+                },
+                "disabledCalls": []
+            },
+            {
+                "label": "v8.0.0",
+                "block": {
+                    "number": 16601480,
+                    "hash": "0x0a8aa9d2f91d6e5a26793801de3d213eace28afda78d61dcaf35e67a2681a844"
+                },
+                "transaction": {
+                    "hash": "0xf7f5f3819ef820f869720986d6441f40d2d3b2a18ca08dbe18faecbed06d063d",
+                    "index": 0
+                },
+                "disabledCalls": [
+                    "eth_getBlockByNumber",
+                    "eth_getBlockByHash",
+                    "eth_getTransactionByHash",
+                    "eth_getTransactionReceipt",
+                    "eth_getBlockReceipts",
+                    "eth_getTransactionByBlockHashAndIndex",
+                    "eth_getTransactionByBlockNumberAndIndex",
+                    "eth_getBlockTransactionCountByHash",
+                    "eth_getBlockTransactionCountByNumber",
+                    "eth_getTransactionCount"
+                ]
+            }
+        ] 
     },
     "chain": {
         "id": "xrpl-evm-devnet",

--- a/modules/evm/configs/localnet.module.config.json
+++ b/modules/evm/configs/localnet.module.config.json
@@ -39,7 +39,38 @@
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
-        }
+        },
+        "rpc": [
+            {
+                "label": "v9.0.0",
+                "block": {
+                    "number": 504,
+                    "hash": "0x9571f62a6e9bdb4dbc87f2aeec9214d416dcc1332c86475ed9b554d363858fc3"
+                },
+                "transaction": {
+                    "hash": "0x02258daf4eff825687c71676469bb66bbf384d35cbf13863738f8a9185c079cc",
+                    "index": 0
+                },
+                "disabledCalls": [
+                    "eth_gasPrice",
+                    "eth_feeHistory"
+                ]
+            },
+            {
+                "label": "v8.0.0",
+                "block": {
+                    "number": 84,
+                    "hash": "0x25b60b46dd51369334124938cf4190a315bcbf21cacd65ec60605d5ccb86f83b"
+                },
+                "transaction": {
+                    "hash": "0x4e73cb2059b1578d684a5781397854f86aadc1e340c8bb132ac2af1e60dd90e0",
+                    "index": 0
+                },
+                "disabledCalls": [
+                    "eth_gasPrice"
+                ]
+            }
+        ] 
     },
     "chain": {
         "id": "xrplevm_localnet",

--- a/modules/evm/configs/mainnet.module.config.json
+++ b/modules/evm/configs/mainnet.module.config.json
@@ -39,7 +39,23 @@
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
-        }
+        },
+        "rpc": [
+            {
+                "label": "v8.0.0",
+                "block": {
+                    "number": 3521556,
+                    "hash": "0x856632b7be8d89337f9675e5828e7d4ffb286b541d3e3f1dbb5d2bd2d42e3161"
+                },
+                "transaction": {
+                    "hash": "0xd1d82250ce64b2076c9c02b87539c3306bb4872d733de82c0a765de3c36cf8ce",
+                    "index": 0
+                },
+                "disabledCalls": [
+                    "eth_getBlockReceipts"
+                ]
+            }
+        ]
     },
     "chain": {
         "id": "xrpl-evm",

--- a/modules/evm/configs/mainnet.module.config.json
+++ b/modules/evm/configs/mainnet.module.config.json
@@ -5,6 +5,7 @@
         "networks": {
             "xrplevm_mainnet": {
                 "url": "https://rpc.xrplevm.org",
+                "archivalUrl": "https://full-history-25843ee0.xrplevm.org",
                 "accounts": [
                     "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100",
                     "5b726ed6e1d4fdeec6ec7526d71c96218f6ebe4d7b10928732c49a242dd6bea9"
@@ -41,6 +42,18 @@
             "faucetFund": "10000000000000000000"
         },
         "rpc": [
+            {
+                "label": "v9.0.0",
+                "block": {
+                    "number": 4688721,
+                    "hash": "0x136592e4a8f7c05f151cb6d4135d0d7841361ca9b6d0082dd093925c3e3b7477"
+                },
+                "transaction": {
+                    "hash": "0x79c6263bfe61da6eace2dcc17990856702e6d33d212567dcc9e3159b606bb80f",
+                    "index": 0
+                },
+                "disabledCalls": []
+            },
             {
                 "label": "v8.0.0",
                 "block": {

--- a/modules/evm/configs/testnet.module.config.json
+++ b/modules/evm/configs/testnet.module.config.json
@@ -39,7 +39,44 @@
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
-        }
+        },
+        "rpc": [
+            {
+                "label": "v9.0.0",
+                "block": {
+                    "number": 4471781,
+                    "hash": "0xdcf1d3b001fffa8e1825865e5c3a7e425eaa2a936e795833bb904041938317e0"
+                },
+                "transaction": {
+                    "hash": "0xe59812bc92cda88de7a88ee565c1f28aed9b3747d7e0d7df73d436e749126509",
+                    "index": 2
+                },
+                "disabledCalls": []
+            },
+            {
+                "label": "v8.0.0",
+                "block": {
+                    "number": 3826800,
+                    "hash": "0x7d4f9d8fb36ca91a9c618b76bba5039cecbbafd7ee6efe8163e4b87ee1fde083"
+                },
+                "transaction": {
+                    "hash": "0x5c995ca814cce1043928b1901efebcc67a364ba819428ea709c27c1ac1fef0d7",
+                    "index": 0
+                },
+                "disabledCalls": [
+                    "eth_getBlockByNumber",
+                    "eth_getBlockByHash",
+                    "eth_getTransactionByHash",
+                    "eth_getTransactionReceipt",
+                    "eth_getBlockReceipts",
+                    "eth_getTransactionByBlockHashAndIndex",
+                    "eth_getTransactionByBlockNumberAndIndex",
+                    "eth_getBlockTransactionCountByHash",
+                    "eth_getBlockTransactionCountByNumber",
+                    "eth_getTransactionCount"
+                ]
+            }
+        ] 
     },
     "chain": {
         "id": "xrpl-evm",

--- a/modules/evm/configs/testnet.module.config.json
+++ b/modules/evm/configs/testnet.module.config.json
@@ -5,6 +5,7 @@
         "networks": {
             "xrplevm_testnet": {
                 "url": "https://rpc.testnet.xrplevm.org",
+                "archivalUrl": "https://full-history-0.testnet.xrplevm.org",
                 "accounts": [
                     "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100",
                     "25ed64e00aefb0081cc5c799e4abc916b16961a54a7c97138f7e98b357a60161"
@@ -63,18 +64,7 @@
                     "hash": "0x5c995ca814cce1043928b1901efebcc67a364ba819428ea709c27c1ac1fef0d7",
                     "index": 0
                 },
-                "disabledCalls": [
-                    "eth_getBlockByNumber",
-                    "eth_getBlockByHash",
-                    "eth_getTransactionByHash",
-                    "eth_getTransactionReceipt",
-                    "eth_getBlockReceipts",
-                    "eth_getTransactionByBlockHashAndIndex",
-                    "eth_getTransactionByBlockNumberAndIndex",
-                    "eth_getBlockTransactionCountByHash",
-                    "eth_getBlockTransactionCountByNumber",
-                    "eth_getTransactionCount"
-                ]
+                "disabledCalls": []
             }
         ] 
     },

--- a/modules/evm/hardhat.config.ts
+++ b/modules/evm/hardhat.config.ts
@@ -1,6 +1,9 @@
+import * as dotenv from "dotenv";
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import moduleConfig from "./module.config.json";
+
+dotenv.config();
 
 const config: HardhatUserConfig = {
     ...moduleConfig.hardhat,

--- a/modules/evm/module.config.json
+++ b/modules/evm/module.config.json
@@ -1,10 +1,10 @@
 {
     "hardhat": {
-        "defaultNetwork": "xrplevm_localnet",
+        "defaultNetwork": "xrplevm_testnet",
         "solidity": "0.8.20",
         "networks": {
-            "xrplevm_localnet": {
-                "url": "http://localhost:8545",
+            "xrplevm_testnet": {
+                "url": "https://rpc.testnet.xrplevm.org",
                 "accounts": [
                     "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100",
                     "25ed64e00aefb0081cc5c799e4abc916b16961a54a7c97138f7e98b357a60161"
@@ -34,22 +34,62 @@
                 "event Transfer(address indexed from, address indexed to, uint256 value)",
                 "event Approval(address indexed owner, address indexed spender, uint256 value)"
             ],
-            "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
-            "owner": "0x10CDF544aeeEbadA19198a21a38D653A95e32272",
+            "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+            "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
-        }
+        },
+        "rpc": [
+            {
+                "label": "v9.0.0",
+                "block": {
+                    "number": 4471781,
+                    "hash": "0xdcf1d3b001fffa8e1825865e5c3a7e425eaa2a936e795833bb904041938317e0"
+                },
+                "transaction": {
+                    "hash": "0xe59812bc92cda88de7a88ee565c1f28aed9b3747d7e0d7df73d436e749126509",
+                    "index": 2
+                },
+                "disabledCalls": []
+            },
+            {
+                "label": "v8.0.0",
+                "block": {
+                    "number": 3826800,
+                    "hash": "0x7d4f9d8fb36ca91a9c618b76bba5039cecbbafd7ee6efe8163e4b87ee1fde083"
+                },
+                "transaction": {
+                    "hash": "0x5c995ca814cce1043928b1901efebcc67a364ba819428ea709c27c1ac1fef0d7",
+                    "index": 0
+                },
+                "disabledCalls": [
+                    "eth_getBlockByNumber",
+                    "eth_getBlockByHash",
+                    "eth_getTransactionByHash",
+                    "eth_getTransactionReceipt",
+                    "eth_getBlockReceipts",
+                    "eth_getTransactionByBlockHashAndIndex",
+                    "eth_getTransactionByBlockNumberAndIndex",
+                    "eth_getBlockTransactionCountByHash",
+                    "eth_getBlockTransactionCountByNumber",
+                    "eth_getTransactionCount"
+                ]
+            }
+        ] 
     },
     "chain": {
-        "id": "xrplevm_localnet",
-        "name": "xrplevm_localnet",
-        "chainId": 100,
-        "env": "localnet",
+        "id": "xrpl-evm",
+        "name": "xrpl-evm",
+        "chainId": 1449000,
+        "env": "testnet",
         "type": "evm",
         "symbol": "XRP",
         "nativeToken": {
-            "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
+            "symbol": "XRP",
+            "decimals": 18,
+            "name": "XRP",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         }
     }
 }

--- a/modules/evm/module.config.json
+++ b/modules/evm/module.config.json
@@ -1,13 +1,13 @@
 {
     "hardhat": {
-        "defaultNetwork": "xrplevm_testnet",
+        "defaultNetwork": "xrplevm_localnet",
         "solidity": "0.8.20",
         "networks": {
-            "xrplevm_testnet": {
-                "url": "https://rpc.testnet.xrplevm.org",
+            "xrplevm_localnet": {
+                "url": "http://localhost:8545",
                 "accounts": [
-                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100",
-                    "25ed64e00aefb0081cc5c799e4abc916b16961a54a7c97138f7e98b357a60161"
+                    "1bacb3ef3d80d8f148299bd21a56d9a78048dc2e20ddab25713a408f2d1f4d5e",
+                    "d8161fd5fdf4eb216a6556dc639a2543b0ed9abdbceb9971fe08cfba56f588c8"
                 ]
             }
         }
@@ -34,8 +34,8 @@
                 "event Transfer(address indexed from, address indexed to, uint256 value)",
                 "event Approval(address indexed owner, address indexed spender, uint256 value)"
             ],
-            "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-            "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
+            "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
+            "owner": "0x10CDF544aeeEbadA19198a21a38D653A95e32272",
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
@@ -44,52 +44,43 @@
             {
                 "label": "v9.0.0",
                 "block": {
-                    "number": 4471781,
-                    "hash": "0xdcf1d3b001fffa8e1825865e5c3a7e425eaa2a936e795833bb904041938317e0"
+                    "number": 504,
+                    "hash": "0x9571f62a6e9bdb4dbc87f2aeec9214d416dcc1332c86475ed9b554d363858fc3"
                 },
                 "transaction": {
-                    "hash": "0xe59812bc92cda88de7a88ee565c1f28aed9b3747d7e0d7df73d436e749126509",
-                    "index": 2
+                    "hash": "0x02258daf4eff825687c71676469bb66bbf384d35cbf13863738f8a9185c079cc",
+                    "index": 0
                 },
-                "disabledCalls": []
+                "disabledCalls": [
+                    "eth_gasPrice",
+                    "eth_feeHistory"
+                ]
             },
             {
                 "label": "v8.0.0",
                 "block": {
-                    "number": 3826800,
-                    "hash": "0x7d4f9d8fb36ca91a9c618b76bba5039cecbbafd7ee6efe8163e4b87ee1fde083"
+                    "number": 84,
+                    "hash": "0x25b60b46dd51369334124938cf4190a315bcbf21cacd65ec60605d5ccb86f83b"
                 },
                 "transaction": {
-                    "hash": "0x5c995ca814cce1043928b1901efebcc67a364ba819428ea709c27c1ac1fef0d7",
+                    "hash": "0x4e73cb2059b1578d684a5781397854f86aadc1e340c8bb132ac2af1e60dd90e0",
                     "index": 0
                 },
                 "disabledCalls": [
-                    "eth_getBlockByNumber",
-                    "eth_getBlockByHash",
-                    "eth_getTransactionByHash",
-                    "eth_getTransactionReceipt",
-                    "eth_getBlockReceipts",
-                    "eth_getTransactionByBlockHashAndIndex",
-                    "eth_getTransactionByBlockNumberAndIndex",
-                    "eth_getBlockTransactionCountByHash",
-                    "eth_getBlockTransactionCountByNumber",
-                    "eth_getTransactionCount"
+                    "eth_gasPrice"
                 ]
             }
         ] 
     },
     "chain": {
-        "id": "xrpl-evm",
-        "name": "xrpl-evm",
-        "chainId": 1449000,
-        "env": "testnet",
+        "id": "xrplevm_localnet",
+        "name": "xrplevm_localnet",
+        "chainId": 100,
+        "env": "localnet",
         "type": "evm",
         "symbol": "XRP",
         "nativeToken": {
-            "symbol": "XRP",
-            "decimals": 18,
-            "name": "XRP",
-            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+            "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
         }
     }
 }

--- a/modules/evm/module.config.json
+++ b/modules/evm/module.config.json
@@ -1,13 +1,14 @@
 {
     "hardhat": {
-        "defaultNetwork": "xrplevm_localnet",
+        "defaultNetwork": "xrplevm_testnet",
         "solidity": "0.8.20",
         "networks": {
-            "xrplevm_localnet": {
-                "url": "http://localhost:8545",
+            "xrplevm_testnet": {
+                "url": "https://rpc.testnet.xrplevm.org",
+                "archivalUrl": "https://full-history-0.testnet.xrplevm.org",
                 "accounts": [
-                    "1bacb3ef3d80d8f148299bd21a56d9a78048dc2e20ddab25713a408f2d1f4d5e",
-                    "d8161fd5fdf4eb216a6556dc639a2543b0ed9abdbceb9971fe08cfba56f588c8"
+                    "f81159b8509dbabec1fb48fbbae0bd51153105bb5d39f061192096c40274d100",
+                    "25ed64e00aefb0081cc5c799e4abc916b16961a54a7c97138f7e98b357a60161"
                 ]
             }
         }
@@ -34,8 +35,8 @@
                 "event Transfer(address indexed from, address indexed to, uint256 value)",
                 "event Approval(address indexed owner, address indexed spender, uint256 value)"
             ],
-            "contractAddress": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517",
-            "owner": "0x10CDF544aeeEbadA19198a21a38D653A95e32272",
+            "contractAddress": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+            "owner": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
             "amount": "1",
             "burnAmount": "1",
             "faucetFund": "10000000000000000000"
@@ -44,43 +45,41 @@
             {
                 "label": "v9.0.0",
                 "block": {
-                    "number": 504,
-                    "hash": "0x9571f62a6e9bdb4dbc87f2aeec9214d416dcc1332c86475ed9b554d363858fc3"
+                    "number": 4471781,
+                    "hash": "0xdcf1d3b001fffa8e1825865e5c3a7e425eaa2a936e795833bb904041938317e0"
                 },
                 "transaction": {
-                    "hash": "0x02258daf4eff825687c71676469bb66bbf384d35cbf13863738f8a9185c079cc",
-                    "index": 0
+                    "hash": "0xe59812bc92cda88de7a88ee565c1f28aed9b3747d7e0d7df73d436e749126509",
+                    "index": 2
                 },
-                "disabledCalls": [
-                    "eth_gasPrice",
-                    "eth_feeHistory"
-                ]
+                "disabledCalls": []
             },
             {
                 "label": "v8.0.0",
                 "block": {
-                    "number": 84,
-                    "hash": "0x25b60b46dd51369334124938cf4190a315bcbf21cacd65ec60605d5ccb86f83b"
+                    "number": 3826800,
+                    "hash": "0x7d4f9d8fb36ca91a9c618b76bba5039cecbbafd7ee6efe8163e4b87ee1fde083"
                 },
                 "transaction": {
-                    "hash": "0x4e73cb2059b1578d684a5781397854f86aadc1e340c8bb132ac2af1e60dd90e0",
+                    "hash": "0x5c995ca814cce1043928b1901efebcc67a364ba819428ea709c27c1ac1fef0d7",
                     "index": 0
                 },
-                "disabledCalls": [
-                    "eth_gasPrice"
-                ]
+                "disabledCalls": []
             }
         ] 
     },
     "chain": {
-        "id": "xrplevm_localnet",
-        "name": "xrplevm_localnet",
-        "chainId": 100,
-        "env": "localnet",
+        "id": "xrpl-evm",
+        "name": "xrpl-evm",
+        "chainId": 1449000,
+        "env": "testnet",
         "type": "evm",
         "symbol": "XRP",
         "nativeToken": {
-            "address": "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
+            "symbol": "XRP",
+            "decimals": 18,
+            "name": "XRP",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         }
     }
 }

--- a/modules/evm/package.json
+++ b/modules/evm/package.json
@@ -26,6 +26,7 @@
         "@testing/mocha": "workspace:*",
         "@testing/hardhat": "workspace:*",
         "@firewatch/core": "workspace:*",
-        "@types/chai": "^5.0.1"
+        "@types/chai": "^5.0.1",
+        "dotenv": "^16.4.7"
     }
 }

--- a/modules/evm/src/config/config.ts
+++ b/modules/evm/src/config/config.ts
@@ -2,7 +2,9 @@ import { ERC20PrecompileConfig } from "../precompiles/erc20/config/config";
 import { HardhatModuleConfig } from "@testing/hardhat/config";
 import { Chain } from "@firewatch/core/chain";
 import { Account } from "@firewatch/core/account";
+import { RPCConfig } from "../rpc/config/config";
 
 export interface EVMModuleConfig extends Omit<HardhatModuleConfig<Chain, Account>, "network" | "accounts"> {
     erc20: ERC20PrecompileConfig;
+    rpc: RPCConfig;
 }

--- a/modules/evm/src/rpc/config/config.ts
+++ b/modules/evm/src/rpc/config/config.ts
@@ -1,0 +1,13 @@
+import { Block } from "../types/block.types";
+import { Transaction } from "../types/transaction.types";
+
+export type RPCConfig = {
+    rpc: RPCFixtureConfig[];
+};
+
+export type RPCFixtureConfig = {
+    label: string;
+    block: Block;
+    transaction: Transaction;
+    disabledCalls: string[];
+};

--- a/modules/evm/src/rpc/providers/authenticated-jsonrpc-provider.ts
+++ b/modules/evm/src/rpc/providers/authenticated-jsonrpc-provider.ts
@@ -1,0 +1,17 @@
+import { JsonRpcProvider, FetchRequest } from "ethers";
+
+/**
+ * Custom JsonRpcProvider that supports Basic Authentication with username and password.
+ */
+export class AuthenticatedJsonRpcProvider extends JsonRpcProvider {
+    constructor(url: string, username?: string, password?: string) {
+        const fetchRequest = new FetchRequest(url);
+
+        // Add Basic Authentication credentials if username and password are provided
+        if (username && password) {
+            fetchRequest.setCredentials(username, password);
+        }
+
+        super(fetchRequest);
+    }
+}

--- a/modules/evm/src/rpc/types/block.types.ts
+++ b/modules/evm/src/rpc/types/block.types.ts
@@ -1,0 +1,4 @@
+export type Block = {
+    number: number;
+    hash: string;
+};

--- a/modules/evm/src/rpc/types/transaction.types.ts
+++ b/modules/evm/src/rpc/types/transaction.types.ts
@@ -1,0 +1,4 @@
+export type Transaction = {
+    hash: string;
+    index: number;
+};

--- a/modules/evm/src/rpc/utils/disabled-calls.ts
+++ b/modules/evm/src/rpc/utils/disabled-calls.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks if a call is disabled by the given disabled calls.
+ * @param call The call to check.
+ * @param disabledCalls The disabled calls.
+ * @returns Whether the call is disabled.
+ */
+export function isDisabledCall(call: string, disabledCalls: string[]): boolean {
+    return disabledCalls.includes(call);
+}

--- a/modules/evm/src/rpc/utils/env.ts
+++ b/modules/evm/src/rpc/utils/env.ts
@@ -1,0 +1,39 @@
+/**
+ * Gets RPC username from environment variable.
+ * @param networkName The network name (e.g., 'xrplevm_testnet', 'xrplevm_devnet')
+ * @returns The username if set, undefined otherwise
+ */
+export function getRpcUsername(networkName: string): string | undefined {
+    // Convert network name to uppercase and replace hyphens with underscores
+    // e.g., 'xrplevm_testnet' -> 'XRPLEVM_TESTNET'
+    const envKey = `${networkName.toUpperCase().replace(/-/g, "_")}_RPC_USERNAME`;
+    return process.env[envKey];
+}
+
+/**
+ * Gets RPC password from environment variable.
+ * @param networkName The network name (e.g., 'xrplevm_testnet', 'xrplevm_devnet')
+ * @returns The password if set, undefined otherwise
+ */
+export function getRpcPassword(networkName: string): string | undefined {
+    // Convert network name to uppercase and replace hyphens with underscores
+    // e.g., 'xrplevm_testnet' -> 'XRPLEVM_TESTNET'
+    const envKey = `${networkName.toUpperCase().replace(/-/g, "_")}_RPC_PASSWORD`;
+    return process.env[envKey];
+}
+
+/**
+ * Gets RPC credentials from environment variables.
+ * @param networkName The network name (e.g., 'xrplevm_testnet', 'xrplevm_devnet')
+ * @returns An object with username and password, or undefined if not set
+ */
+export function getRpcCredentials(networkName: string): { username: string; password: string } | undefined {
+    const username = getRpcUsername(networkName);
+    const password = getRpcPassword(networkName);
+
+    if (username && password) {
+        return { username, password };
+    }
+
+    return undefined;
+}

--- a/modules/evm/test/rpc/index.test.ts
+++ b/modules/evm/test/rpc/index.test.ts
@@ -1,0 +1,164 @@
+import { expect } from "chai";
+import moduleConfig from "../../module.config.json";
+import { ethers } from "hardhat";
+import { JsonRpcProvider } from "ethers";
+import { RPCFixtureConfig } from "../../src/rpc/config/config";
+import { isDisabledCall } from "../../src/rpc/utils/disabled-calls";
+import { describeOrSkip } from "@testing/mocha/utils";
+
+describe("Ethereum RPC", () => {
+    let rpcProvider: JsonRpcProvider;
+
+    before(async () => {
+        // Get the RPC URL from hardhat network configuration
+        const defaultNetwork = moduleConfig.hardhat.defaultNetwork;
+        const networkConfig = moduleConfig.hardhat.networks[defaultNetwork as keyof typeof moduleConfig.hardhat.networks];
+        const rpcUrl = networkConfig.url;
+
+        // Create a JsonRpcProvider for direct RPC calls
+        rpcProvider = new JsonRpcProvider(rpcUrl);
+    });
+
+    // Get fixtures from config - handle both old structure (rpc.block/transaction) and new structure (fixtures array)
+    const fixtures: RPCFixtureConfig[] = moduleConfig.contracts.rpc as RPCFixtureConfig[];
+
+    fixtures.forEach((fixture: RPCFixtureConfig) => {
+        describe(`Fixture: ${fixture.label}`, () => {
+            const blockHash = fixture.block.hash;
+            const blockNumber = fixture.block.number;
+            const txHash = fixture.transaction.hash;
+            const txIndex = fixture.transaction.index;
+
+            describeOrSkip("eth_getBlockByNumber", !isDisabledCall("eth_getBlockByNumber", fixture.disabledCalls), () => {
+                it("should return the block by number", async () => {
+                    const blockHex = `0x${blockNumber.toString(16)}`;
+                    const block = await rpcProvider.send("eth_getBlockByNumber", [blockHex, false]);
+                    expect(block?.hash).to.equal(blockHash);
+                    expect(parseInt(block?.number, 16)).to.equal(blockNumber);
+                });
+            });
+
+            describeOrSkip("eth_getBlockByHash", !isDisabledCall("eth_getBlockByHash", fixture.disabledCalls), () => {
+                it("should return the block by hash", async () => {
+                    const block = await ethers.provider.getBlock(blockHash);
+                    expect(block?.hash).to.equal(blockHash);
+                    expect(block?.number).to.equal(blockNumber);
+                });
+            });
+
+            describeOrSkip("eth_getBlockReceipts", !isDisabledCall("eth_getBlockReceipts", fixture.disabledCalls), () => {
+                it("should return the block receipts", async () => {
+                    const blockHex = `0x${blockNumber.toString(16)}`;
+                    const receipts = await rpcProvider.send("eth_getBlockReceipts", [blockHex]);
+                    expect(receipts).to.be.an("array");
+                    expect(receipts.length).to.be.greaterThan(0);
+                    const receipt = receipts.find((r: any) => r.transactionHash === txHash);
+                    expect(receipt?.transactionHash).to.equal(txHash);
+                    expect(parseInt(receipt?.blockNumber, 16)).to.equal(blockNumber);
+                });
+            });
+
+            describeOrSkip("eth_getTransactionByHash", !isDisabledCall("eth_getTransactionByHash", fixture.disabledCalls), () => {
+                it("should return the transaction by hash", async () => {
+                    const transaction = await ethers.provider.getTransaction(txHash);
+                    expect(transaction?.hash).to.equal(txHash);
+                    expect(transaction?.blockNumber).to.equal(blockNumber);
+                    expect(transaction?.blockHash).to.equal(blockHash);
+                });
+            });
+
+            describeOrSkip("eth_getTransactionReceipt", !isDisabledCall("eth_getTransactionReceipt", fixture.disabledCalls), () => {
+                it("should return the transaction receipt by hash", async () => {
+                    const receipt = await ethers.provider.getTransactionReceipt(txHash);
+                    expect(receipt?.hash).to.equal(txHash);
+                    expect(receipt?.blockNumber).to.equal(blockNumber);
+                    expect(receipt?.blockHash).to.equal(blockHash);
+                });
+            });
+
+            describeOrSkip(
+                "eth_getTransactionByBlockHashAndIndex",
+                !isDisabledCall("eth_getTransactionByBlockHashAndIndex", fixture.disabledCalls),
+                () => {
+                    it("should return the transaction by block hash and index", async () => {
+                        const transaction = await rpcProvider.send("eth_getTransactionByBlockHashAndIndex", [
+                            blockHash,
+                            `0x${txIndex.toString(16)}`,
+                        ]);
+                        expect(transaction?.hash).to.equal(txHash);
+                        expect(parseInt(transaction?.blockNumber, 16)).to.equal(blockNumber);
+                        expect(transaction?.blockHash).to.equal(blockHash);
+                    });
+                },
+            );
+
+            describeOrSkip(
+                "eth_getTransactionByBlockNumberAndIndex",
+                !isDisabledCall("eth_getTransactionByBlockNumberAndIndex", fixture.disabledCalls),
+                () => {
+                    it("should return the transaction by block number and index", async () => {
+                        const blockHex = `0x${blockNumber.toString(16)}`;
+                        const transaction = await rpcProvider.send("eth_getTransactionByBlockNumberAndIndex", [
+                            blockHex,
+                            `0x${txIndex.toString(16)}`,
+                        ]);
+                        expect(transaction?.hash).to.equal(txHash);
+                        expect(parseInt(transaction?.blockNumber, 16)).to.equal(blockNumber);
+                        expect(transaction?.blockHash).to.equal(blockHash);
+                    });
+                },
+            );
+
+            describeOrSkip(
+                "eth_getBlockTransactionCountByHash",
+                !isDisabledCall("eth_getBlockTransactionCountByHash", fixture.disabledCalls),
+                () => {
+                    it("should return the transaction count by block hash", async () => {
+                        const count = await rpcProvider.send("eth_getBlockTransactionCountByHash", [blockHash]);
+                        expect(parseInt(count, 16)).to.be.greaterThan(0);
+                    });
+                },
+            );
+
+            describeOrSkip(
+                "eth_getBlockTransactionCountByNumber",
+                !isDisabledCall("eth_getBlockTransactionCountByNumber", fixture.disabledCalls),
+                () => {
+                    it("should return the transaction count by block number", async () => {
+                        const blockHex = `0x${blockNumber.toString(16)}`;
+                        const count = await rpcProvider.send("eth_getBlockTransactionCountByNumber", [blockHex]);
+                        expect(parseInt(count, 16)).to.be.greaterThan(0);
+                    });
+                },
+            );
+
+            describeOrSkip("eth_getTransactionCount", !isDisabledCall("eth_getTransactionCount", fixture.disabledCalls), () => {
+                it("should return the transaction count", async () => {
+                    // Get an address from the transaction
+                    const transaction = await rpcProvider.send("eth_getTransactionByHash", [txHash]);
+                    const address = transaction.from;
+                    const transactionCount = await rpcProvider.send("eth_getTransactionCount", [address, "latest"]);
+                    expect(parseInt(transactionCount, 16)).to.be.a("number");
+                });
+            });
+
+            describeOrSkip("eth_feeHistory", !isDisabledCall("eth_feeHistory", fixture.disabledCalls), () => {
+                it("should return the fee history", async () => {
+                    const feeHistory = await rpcProvider.send("eth_feeHistory", ["0x1", "latest", [25, 75]]);
+                    expect(feeHistory).to.have.property("oldestBlock");
+                    expect(feeHistory).to.have.property("baseFeePerGas");
+                    expect(feeHistory).to.have.property("gasUsedRatio");
+                });
+            });
+
+            describeOrSkip("eth_gasPrice", !isDisabledCall("eth_gasPrice", fixture.disabledCalls), () => {
+                it("should return the gas price", async () => {
+                    const gasPrice = await rpcProvider.send("eth_gasPrice", []);
+                    expect(gasPrice).to.be.a("string");
+                    expect(gasPrice).to.match(/^0x[0-9a-fA-F]+$/);
+                    expect(parseInt(gasPrice, 16)).to.be.greaterThan(0);
+                });
+            });
+        });
+    });
+});

--- a/modules/evm/test/rpc/index.test.ts
+++ b/modules/evm/test/rpc/index.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
 import moduleConfig from "../../module.config.json";
-import { ethers } from "hardhat";
 import { JsonRpcProvider } from "ethers";
 import { RPCFixtureConfig } from "../../src/rpc/config/config";
 import { isDisabledCall } from "../../src/rpc/utils/disabled-calls";
 import { describeOrSkip } from "@testing/mocha/utils";
+import { AuthenticatedJsonRpcProvider } from "../../src/rpc/providers/authenticated-jsonrpc-provider";
+import { getRpcCredentials } from "../../src/rpc/utils/env";
 
 describe("Ethereum RPC", () => {
     let rpcProvider: JsonRpcProvider;
@@ -13,10 +14,13 @@ describe("Ethereum RPC", () => {
         // Get the RPC URL from hardhat network configuration
         const defaultNetwork = moduleConfig.hardhat.defaultNetwork;
         const networkConfig = moduleConfig.hardhat.networks[defaultNetwork as keyof typeof moduleConfig.hardhat.networks];
-        const rpcUrl = networkConfig.url;
+        const rpcUrl = networkConfig.archivalUrl || networkConfig.url;
 
-        // Create a JsonRpcProvider for direct RPC calls
-        rpcProvider = new JsonRpcProvider(rpcUrl);
+        // Get username and password from environment variables
+        const credentials = getRpcCredentials(defaultNetwork as string);
+
+        // Create an authenticated JsonRpcProvider if credentials are provided, otherwise use regular provider
+        rpcProvider = new AuthenticatedJsonRpcProvider(rpcUrl, credentials?.username, credentials?.password);
     });
 
     // Get fixtures from config - handle both old structure (rpc.block/transaction) and new structure (fixtures array)
@@ -40,7 +44,7 @@ describe("Ethereum RPC", () => {
 
             describeOrSkip("eth_getBlockByHash", !isDisabledCall("eth_getBlockByHash", fixture.disabledCalls), () => {
                 it("should return the block by hash", async () => {
-                    const block = await ethers.provider.getBlock(blockHash);
+                    const block = await rpcProvider.getBlock(blockHash);
                     expect(block?.hash).to.equal(blockHash);
                     expect(block?.number).to.equal(blockNumber);
                 });
@@ -60,7 +64,7 @@ describe("Ethereum RPC", () => {
 
             describeOrSkip("eth_getTransactionByHash", !isDisabledCall("eth_getTransactionByHash", fixture.disabledCalls), () => {
                 it("should return the transaction by hash", async () => {
-                    const transaction = await ethers.provider.getTransaction(txHash);
+                    const transaction = await rpcProvider.getTransaction(txHash);
                     expect(transaction?.hash).to.equal(txHash);
                     expect(transaction?.blockNumber).to.equal(blockNumber);
                     expect(transaction?.blockHash).to.equal(blockHash);
@@ -69,7 +73,7 @@ describe("Ethereum RPC", () => {
 
             describeOrSkip("eth_getTransactionReceipt", !isDisabledCall("eth_getTransactionReceipt", fixture.disabledCalls), () => {
                 it("should return the transaction receipt by hash", async () => {
-                    const receipt = await ethers.provider.getTransactionReceipt(txHash);
+                    const receipt = await rpcProvider.getTransactionReceipt(txHash);
                     expect(receipt?.hash).to.equal(txHash);
                     expect(receipt?.blockNumber).to.equal(blockNumber);
                     expect(receipt?.blockHash).to.equal(blockHash);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,10 +141,10 @@ importers:
     dependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.8
-        version: 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+        version: 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(246ppa6rbqhpy2cfbyhofx2xom)
+        version: 5.0.0(6qv3amog762zhvysfqmmoxayvu)
       bignumber.js:
         specifier: ^9.1.2
         version: 9.1.2
@@ -156,7 +156,7 @@ importers:
         version: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat:
         specifier: ^2.22.18
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
     devDependencies:
       '@firewatch/core':
         specifier: workspace:*
@@ -179,12 +179,15 @@ importers:
       '@types/chai':
         specifier: ^5.0.1
         version: 5.0.1
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
 
   packages/bridge:
     dependencies:
       '@axelar-network/axelarjs-sdk':
         specifier: github:banasa44/axelarjs-sdk#chore/release-0.17.1
-        version: https://codeload.github.com/banasa44/axelarjs-sdk/tar.gz/f55f46a6ae4d77477c87e2f4720a680bec7c5b34(bufferutil@4.0.5)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.7)
+        version: https://codeload.github.com/banasa44/axelarjs-sdk/tar.gz/f55f46a6ae4d77477c87e2f4720a680bec7c5b34(bufferutil@4.0.5)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.7)
       '@firewatch/core':
         specifier: workspace:*
         version: link:../core
@@ -218,7 +221,7 @@ importers:
         version: link:../shared/xrpl
       '@swisstype/essential':
         specifier: ^0.1.1
-        version: 0.1.2(typescript@5.8.3)
+        version: 0.1.2(typescript@5.9.3)
       '@tanstack/react-query':
         specifier: ^5.52.2
         version: 5.66.7(react@19.0.0)
@@ -233,13 +236,13 @@ importers:
         version: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
+        version: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
       xchain-sdk:
         specifier: workspace:*
         version: link:../xchain-sdk
@@ -446,7 +449,7 @@ importers:
         version: link:../../shared/tsup
       typescript:
         specifier: latest
-        version: 5.9.2
+        version: 5.9.3
 
   packages/proto/evmos:
     dependencies:
@@ -480,7 +483,7 @@ importers:
         version: link:../../shared/tsup
       typescript:
         specifier: latest
-        version: 5.9.2
+        version: 5.9.3
 
   packages/shared/eslint:
     devDependencies:
@@ -544,10 +547,10 @@ importers:
         version: 29.5.14
       '@types/node':
         specifier: latest
-        version: 22.15.19
+        version: 25.0.9
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
 
   packages/shared/modules:
     devDependencies:
@@ -562,7 +565,7 @@ importers:
         version: link:../tsup
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
 
   packages/shared/number:
     devDependencies:
@@ -577,13 +580,13 @@ importers:
         version: link:../tsup
       '@types/node':
         specifier: latest
-        version: 22.15.19
+        version: 25.0.9
       bignumber.js:
         specifier: ^9.1.2
         version: 9.1.2
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
 
   packages/shared/tsconfig: {}
 
@@ -597,13 +600,13 @@ importers:
         version: link:../tsconfig
       '@types/node':
         specifier: latest
-        version: 22.15.19
+        version: 25.0.9
       tsup:
         specifier: ^8.2.4
-        version: 8.3.6(typescript@5.8.3)
+        version: 8.3.6(typescript@5.9.3)
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
 
   packages/shared/utils:
     devDependencies:
@@ -621,16 +624,16 @@ importers:
         version: 29.5.14
       '@types/node':
         specifier: latest
-        version: 22.15.19
+        version: 25.0.9
       '@types/validator':
         specifier: ^13.12.1
         version: 13.12.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+        version: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
       validator:
         specifier: 13.12.0
         version: 13.12.0
@@ -648,19 +651,19 @@ importers:
         version: link:../tsup
       '@swisstype/essential':
         specifier: ^0.1.1
-        version: 0.1.2(typescript@5.8.3)
+        version: 0.1.2(typescript@5.9.3)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
       '@types/node':
         specifier: latest
-        version: 22.15.19
+        version: 25.0.9
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+        version: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       typescript:
         specifier: latest
-        version: 5.8.3
+        version: 5.9.3
       xrpl:
         specifier: 3.0.0
         version: 3.0.0(bufferutil@4.0.5)(encoding@0.1.13)(utf-8-validate@5.0.7)
@@ -682,10 +685,10 @@ importers:
         version: link:../../core
       '@nomiclabs/hardhat-ethers':
         specifier: ^2.2.2
-        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+        version: 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@nomiclabs/hardhat-waffle':
         specifier: ^2.0.3
-        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(encoding@0.1.13)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+        version: 2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(encoding@0.1.13)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@shared/eslint':
         specifier: workspace:*
         version: link:../../shared/eslint
@@ -706,7 +709,7 @@ importers:
         version: 4.5.0
       hardhat:
         specifier: ^2.12.7
-        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+        version: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
   packages/testing/mocha:
     dependencies:
@@ -1105,12 +1108,15 @@ packages:
 
   '@cosmjs/crypto@0.31.3':
     resolution: {integrity: sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==}
+    deprecated: This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.
 
   '@cosmjs/crypto@0.33.0':
     resolution: {integrity: sha512-kkt06t+cFW2XRGDGUZ0cVf5yoQ2OhZnubwbYbz3QXdyhf1qOXYVPRThfFPsko7dssr+e8Yy4OJKlh5SLA8DXTQ==}
+    deprecated: This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.
 
   '@cosmjs/crypto@0.33.1':
     resolution: {integrity: sha512-U4kGIj/SNBzlb2FGgA0sMR0MapVgJUg8N+oIAiN5+vl4GZ3aefmoL1RDyTrFS/7HrB+M+MtHsxC0tvEu4ic/zA==}
+    deprecated: This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.
 
   '@cosmjs/encoding@0.31.3':
     resolution: {integrity: sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==}
@@ -2650,14 +2656,11 @@ packages:
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
 
-  '@types/node@22.15.19':
-    resolution: {integrity: sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==}
-
-  '@types/node@22.15.27':
-    resolution: {integrity: sha512-5fF+eu5mwihV2BeVtX5vijhdaZOfkQTATrePEaXTcKqI16LhJ7gi2/Vhd9OZM0UojcdmiOCVg5rrax+i1MdoQQ==}
-
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
+  '@types/node@25.0.9':
+    resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
 
   '@types/node@8.10.66':
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -4618,8 +4621,8 @@ packages:
     resolution: {integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==}
     deprecated: This library has been deprecated and usage is discouraged.
 
-  ethereumjs-abi@https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
-    resolution: {tarball: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0}
+  ethereumjs-abi@git+https://git@github.com:ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0:
+    resolution: {commit: ee3994657fa7a427238e6ba92a84d0b529bbcde0, repo: git@github.com:ethereumjs/ethereumjs-abi.git, type: git}
     version: 0.6.8
 
   ethereumjs-account@2.0.5:
@@ -7570,6 +7573,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
@@ -8132,16 +8136,6 @@ packages:
   typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -8190,6 +8184,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@5.28.5:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
@@ -8692,11 +8689,11 @@ snapshots:
     optionalDependencies:
       graphql: 16.11.0
 
-  '@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.8.3)':
+  '@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.9.3)':
     dependencies:
-      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.8.3)
+      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.9.3)
       graphql: 16.11.0
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   '@adraffy/ens-normalize@1.10.1': {}
 
@@ -9054,7 +9051,7 @@ snapshots:
 
   '@axelar-network/axelar-gmp-sdk-solidity@5.10.0': {}
 
-  '@axelar-network/axelarjs-sdk@https://codeload.github.com/banasa44/axelarjs-sdk/tar.gz/f55f46a6ae4d77477c87e2f4720a680bec7c5b34(bufferutil@4.0.5)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.7)':
+  '@axelar-network/axelarjs-sdk@https://codeload.github.com/banasa44/axelarjs-sdk/tar.gz/f55f46a6ae4d77477c87e2f4720a680bec7c5b34(bufferutil@4.0.5)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.7)':
     dependencies:
       '@axelar-network/axelar-cgp-solidity': 6.4.0
       '@axelar-network/axelarjs-types': 0.33.0
@@ -9063,7 +9060,7 @@ snapshots:
       '@ethersproject/abstract-provider': 5.8.0
       '@ethersproject/networks': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      '@mysten/sui': 1.29.1(typescript@5.8.3)
+      '@mysten/sui': 1.29.1(typescript@5.9.3)
       '@stellar/stellar-sdk': 13.3.0
       '@types/uuid': 8.3.4
       bech32: 2.0.0
@@ -10276,18 +10273,18 @@ snapshots:
     optionalDependencies:
       '@trufflesuite/bigint-buffer': 1.1.9
 
-  '@gql.tada/cli-utils@1.6.3(@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.8.3))(graphql@16.11.0)(typescript@5.8.3)':
+  '@gql.tada/cli-utils@1.6.3(@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.9.3))(graphql@16.11.0)(typescript@5.9.3)':
     dependencies:
-      '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.8.3)
-      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.8.3)
+      '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.9.3)
+      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.9.3)
       graphql: 16.11.0
-      typescript: 5.8.3
+      typescript: 5.9.3
 
-  '@gql.tada/internal@1.0.8(graphql@16.11.0)(typescript@5.8.3)':
+  '@gql.tada/internal@1.0.8(graphql@16.11.0)(typescript@5.9.3)':
     dependencies:
       '@0no-co/graphql.web': 1.1.2(graphql@16.11.0)
       graphql: 16.11.0
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   '@graphql-typed-document-node/core@3.2.0(graphql@16.11.0)':
     dependencies:
@@ -10333,41 +10330,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.25
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -10403,7 +10365,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -10417,7 +10379,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -10599,7 +10561,7 @@ snapshots:
       '@mysten/utils': 0.0.0
       '@scure/base': 1.2.4
 
-  '@mysten/sui@1.29.1(typescript@5.8.3)':
+  '@mysten/sui@1.29.1(typescript@5.9.3)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.11.0)
       '@mysten/bcs': 1.6.1
@@ -10609,7 +10571,7 @@ snapshots:
       '@scure/base': 1.2.4
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      gql.tada: 1.8.10(graphql@16.11.0)(typescript@5.8.3)
+      gql.tada: 1.8.10(graphql@16.11.0)(typescript@5.9.3)
       graphql: 16.11.0
       poseidon-lite: 0.2.1
       valibot: 0.36.0
@@ -10702,43 +10664,43 @@ snapshots:
       '@nomicfoundation/ethereumjs-rlp': 5.0.4
       ethereum-cryptography: 0.1.3
 
-  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@types/chai-as-promised': 7.1.8
       chai: 4.5.0
       chai-as-promised: 7.1.2(chai@4.5.0)
       deep-eql: 4.1.4
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       ordinal: 1.0.3
 
-  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
 
-  '@nomicfoundation/hardhat-ignition-ethers@0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-ignition-ethers@0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-ignition': 0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ignition': 0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
       '@nomicfoundation/ignition-core': 0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
-  '@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)':
+  '@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)':
     dependencies:
-      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@nomicfoundation/ignition-core': 0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       '@nomicfoundation/ignition-ui': 0.15.9
       chalk: 4.1.2
       debug: 4.4.0(supports-color@8.1.1)
       fs-extra: 10.1.0
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       json5: 2.2.3
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10751,39 +10713,39 @@ snapshots:
       ethereumjs-util: 7.1.5
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
-  '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
-  '@nomicfoundation/hardhat-toolbox@5.0.0(246ppa6rbqhpy2cfbyhofx2xom)':
+  '@nomicfoundation/hardhat-toolbox@5.0.0(6qv3amog762zhvysfqmmoxayvu)':
     dependencies:
-      '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-ignition-ethers': 0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
-      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(chai@4.5.0)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-ignition-ethers': 0.15.9(@nomicfoundation/hardhat-ethers@3.0.8(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@nomicfoundation/hardhat-ignition@0.15.9(@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7))(@nomicfoundation/ignition-core@0.15.9(bufferutil@4.0.5)(utf-8-validate@5.0.7))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomicfoundation/hardhat-verify': 2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
-      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))
       '@types/chai': 5.0.1
       '@types/mocha': 10.0.10
-      '@types/node': 22.15.27
+      '@types/node': 25.0.9
       chai: 4.5.0
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
-      hardhat-gas-reporter: 1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
-      solidity-coverage: 0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
-      ts-node: 10.9.2(@types/node@22.15.27)(typescript@5.9.3)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat-gas-reporter: 1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7)
+      solidity-coverage: 0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      ts-node: 10.9.2(@types/node@25.0.9)(typescript@5.9.3)
       typechain: 8.3.2(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomicfoundation/hardhat-verify@2.0.12(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/address': 5.8.0
       cbor: 8.1.0
       debug: 4.4.0(supports-color@8.1.1)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
       semver: 6.3.1
@@ -10846,10 +10808,10 @@ snapshots:
       ethers: 5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
   '@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
@@ -10876,13 +10838,13 @@ snapshots:
       ethers: 5.7.2(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
-  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(encoding@0.1.13)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
+  '@nomiclabs/hardhat-waffle@2.0.6(@nomiclabs/hardhat-ethers@2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)))(@types/sinon-chai@3.2.12)(ethereum-waffle@4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(encoding@0.1.13)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
+      '@nomiclabs/hardhat-ethers': 2.2.3(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))
       '@types/sinon-chai': 3.2.12
       ethereum-waffle: 4.0.10(@ensdomains/ens@0.4.5)(@ensdomains/resolver@0.2.4)(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.8.0(bufferutil@4.0.5)(utf-8-validate@5.0.7))(encoding@0.1.13)(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typescript@5.9.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
 
   '@openzeppelin/contracts@4.9.6': {}
 
@@ -11417,9 +11379,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@swisstype/essential@0.1.2(typescript@5.8.3)':
+  '@swisstype/essential@0.1.2(typescript@5.9.3)':
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   '@swisstype/string@0.0.4(@swisstype/essential@0.0.5(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
@@ -11499,12 +11461,12 @@ snapshots:
       hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       typechain: 8.3.2(typescript@5.9.3)
 
-  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))':
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))':
     dependencies:
       '@typechain/ethers-v6': 0.5.1(ethers@6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7))(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
       ethers: 6.13.5(bufferutil@4.0.5)(utf-8-validate@5.0.7)
       fs-extra: 9.1.0
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       typechain: 8.3.2(typescript@5.9.3)
 
   '@types/abstract-leveldown@7.2.5': {}
@@ -11650,17 +11612,13 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/node@22.15.19':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.15.27':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/node@25.0.9':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/node@8.10.66': {}
 
@@ -13376,21 +13334,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -13406,13 +13349,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3)):
+  create-jest@29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -14364,7 +14307,7 @@ snapshots:
 
   eth-sig-util@1.4.2:
     dependencies:
-      ethereumjs-abi: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0
+      ethereumjs-abi: git+https://git@github.com:ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0
       ethereumjs-util: 5.2.1
 
   eth-sig-util@3.0.0:
@@ -14479,7 +14422,7 @@ snapshots:
       bn.js: 4.12.1
       ethereumjs-util: 6.2.1
 
-  ethereumjs-abi@https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
+  ethereumjs-abi@git+https://git@github.com:ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0:
     dependencies:
       bn.js: 4.12.1
       ethereumjs-util: 6.2.1
@@ -15315,13 +15258,13 @@ snapshots:
       url-parse-lax: 3.0.0
     optional: true
 
-  gql.tada@1.8.10(graphql@16.11.0)(typescript@5.8.3):
+  gql.tada@1.8.10(graphql@16.11.0)(typescript@5.9.3):
     dependencies:
       '@0no-co/graphql.web': 1.1.2(graphql@16.11.0)
-      '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.8.3)
-      '@gql.tada/cli-utils': 1.6.3(@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.8.3))(graphql@16.11.0)(typescript@5.8.3)
-      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.8.3)
-      typescript: 5.8.3
+      '@0no-co/graphqlsp': 1.12.16(graphql@16.11.0)(typescript@5.9.3)
+      '@gql.tada/cli-utils': 1.6.3(@0no-co/graphqlsp@1.12.16(graphql@16.11.0)(typescript@5.9.3))(graphql@16.11.0)(typescript@5.9.3)
+      '@gql.tada/internal': 1.0.8(graphql@16.11.0)(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
@@ -15349,11 +15292,11 @@ snapshots:
       ajv: 6.12.6
       har-schema: 2.0.0
 
-  hardhat-gas-reporter@1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7):
+  hardhat-gas-reporter@1.0.10(bufferutil@4.0.5)(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7))(utf-8-validate@5.0.7):
     dependencies:
       array-uniq: 1.0.3
       eth-gas-reporter: 0.2.27(bufferutil@4.0.5)(utf-8-validate@5.0.7)
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       sha1: 1.1.1
     transitivePeerDependencies:
       - '@codechecks/client'
@@ -15416,7 +15359,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7):
+  hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -15463,7 +15406,7 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10(bufferutil@4.0.5)(utf-8-validate@5.0.7)
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.15.27)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.0.9)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
@@ -16011,25 +15954,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
@@ -16049,16 +15973,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3)):
+  jest-cli@29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      create-jest: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -16067,37 +15991,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.26.9
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.25
-      ts-node: 10.9.2(@types/node@20.19.25)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
     dependencies:
@@ -16130,7 +16023,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -16156,12 +16049,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.25
-      ts-node: 10.9.2(@types/node@22.15.19)(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@25.0.9)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -16186,8 +16079,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.15.19
-      ts-node: 10.9.2(@types/node@22.15.19)(typescript@5.8.3)
+      '@types/node': 25.0.9
+      ts-node: 10.9.2(@types/node@25.0.9)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -16407,18 +16300,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
@@ -16431,12 +16312,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3)):
+  jest@29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.15.19)(ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3))
+      jest-cli: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17679,7 +17560,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.15.27
+      '@types/node': 20.19.25
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -18514,7 +18395,7 @@ snapshots:
       shelljs: 0.8.5
       web3-utils: 1.10.4
 
-  solidity-coverage@0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)):
+  solidity-coverage@0.8.14(hardhat@2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@solidity-parser/parser': 0.19.0
@@ -18525,7 +18406,7 @@ snapshots:
       ghost-testrpc: 0.0.2
       global-modules: 2.0.0
       globby: 10.0.2
-      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
+      hardhat: 2.22.18(bufferutil@4.0.5)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.7)
       jsonschema: 1.5.0
       lodash: 4.17.21
       mocha: 10.8.2
@@ -19048,26 +18929,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3)))(typescript@5.8.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.1
-      typescript: 5.8.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.9
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
-      esbuild: 0.24.2
-
   ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -19088,24 +18949,25 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.9)
       esbuild: 0.24.2
 
-  ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3):
+  ts-jest@29.2.5(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.25
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@25.0.9)(ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
       make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
+      semver: 7.7.1
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.9
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.9)
+      esbuild: 0.24.2
 
   ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3):
     dependencies:
@@ -19125,33 +18987,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.15.19)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.19
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@22.15.27)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.27
+      '@types/node': 25.0.9
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -19176,32 +19019,6 @@ snapshots:
   tslib@2.8.1: {}
 
   tsort@0.0.1: {}
-
-  tsup@8.3.6(typescript@5.8.3):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.24.2)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.0
-      debug: 4.4.0(supports-color@8.1.1)
-      esbuild: 0.24.2
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1
-      resolve-from: 5.0.0
-      rollup: 4.34.8
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.11
-      tree-kill: 1.2.2
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
 
   tsup@8.3.6(typescript@5.9.3):
     dependencies:
@@ -19362,10 +19179,6 @@ snapshots:
 
   typeforce@1.18.0: {}
 
-  typescript@5.8.3: {}
-
-  typescript@5.9.2: {}
-
   typescript@5.9.3: {}
 
   typewise-core@1.2.0: {}
@@ -19403,6 +19216,8 @@ snapshots:
   undici-types@6.20.0: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   undici@5.28.5:
     dependencies:


### PR DESCRIPTION
# [TA-5978]: test rpc calls with pre upgrade transactions & blocks

## Changes :hammer_and_wrench:

### modules/evm

- Add `rpc` submodule for testing `eth` `rpc` calls.
- Update configuration for `localnet`, `devnet`, `testnet` and `mainnet` environments
